### PR TITLE
Add General Credential Extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
+/.idea
+/out
 nb-configuration.xml

--- a/pom.xml
+++ b/pom.xml
@@ -59,17 +59,17 @@
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.50</version>
+            <version>1.56</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.50</version>
+            <version>1.56</version>
         </dependency>
     </dependencies>
 	

--- a/src/main/java/xades4j/production/SignerBES.java
+++ b/src/main/java/xades4j/production/SignerBES.java
@@ -54,6 +54,7 @@ import xades4j.providers.SignaturePropertiesProvider;
 import xades4j.providers.SigningCertChainException;
 import xades4j.utils.DOMHelper;
 import xades4j.utils.ObjectUtils;
+import xades4j.utils.StringUtils;
 import xades4j.xml.marshalling.SignedPropertiesMarshaller;
 import xades4j.xml.marshalling.UnsignedPropertiesMarshaller;
 import xades4j.xml.marshalling.algorithms.AlgorithmsParametersMarshallingProvider;
@@ -155,11 +156,20 @@ class SignerBES implements XadesSigner
         }
         X509Certificate signingCertificate = signingCertificateChain.get(0);
 
+        String algorithm = signingCertificate.getSigAlgName();
+
+        if (StringUtils.isNullOrEmptyString(algorithm))
+        {
+            // Fallback. If its not possible to extract the Signature Algorithm
+            // Field from the certificate. Use the public key algorithm instead.
+            algorithm = signingCertificate.getPublicKey().getAlgorithm();
+        }
+
         // The XMLSignature (ds:Signature).
         XMLSignature signature = createSignature(
                 signatureDocument,
                 signedDataObjects.getBaseUri(),
-                signingCertificate.getPublicKey().getAlgorithm());
+                algorithm);
 
         signature.setId(signatureId);
 

--- a/src/main/java/xades4j/production/SignerBES.java
+++ b/src/main/java/xades4j/production/SignerBES.java
@@ -160,11 +160,20 @@ class SignerBES implements XadesSigner
         }
         X509Certificate signingCertificate = signingCertificateChain.get(0);
 
+        String algorithm = signingCertificate.getSigAlgName();
+
+        if (StringUtils.isNullOrEmptyString(algorithm))
+        {
+            // Fallback. If its not possible to extract the Signature Algorithm
+            // Field from the certificate. Use the public key algorithm instead.
+            algorithm = signingCertificate.getPublicKey().getAlgorithm();
+        }
+
         // The XMLSignature (ds:Signature).
         XMLSignature signature = createSignature(
                 signatureDocument,
                 signedDataObjects.getBaseUri(),
-                signingCertificate.getPublicKey().getAlgorithm());
+                algorithm);
 
         signature.setId(signatureId);
 

--- a/src/main/java/xades4j/production/SignerBES.java
+++ b/src/main/java/xades4j/production/SignerBES.java
@@ -160,20 +160,11 @@ class SignerBES implements XadesSigner
         }
         X509Certificate signingCertificate = signingCertificateChain.get(0);
 
-        String algorithm = signingCertificate.getSigAlgName();
-
-        if (StringUtils.isNullOrEmptyString(algorithm))
-        {
-            // Fallback. If its not possible to extract the Signature Algorithm
-            // Field from the certificate. Use the public key algorithm instead.
-            algorithm = signingCertificate.getPublicKey().getAlgorithm();
-        }
-
         // The XMLSignature (ds:Signature).
         XMLSignature signature = createSignature(
                 signatureDocument,
                 signedDataObjects.getBaseUri(),
-                algorithm);
+                signingCertificate.getPublicKey().getAlgorithm());
 
         signature.setId(signatureId);
 

--- a/src/main/java/xades4j/providers/impl/DefaultAlgorithmsProviderEx.java
+++ b/src/main/java/xades4j/providers/impl/DefaultAlgorithmsProviderEx.java
@@ -42,9 +42,11 @@ public class DefaultAlgorithmsProviderEx implements AlgorithmsProviderEx
 
     static
     {
-        signatureAlgsMaps = new HashMap<String, Algorithm>(2);
+        signatureAlgsMaps = new HashMap<String, Algorithm>(4);
+        signatureAlgsMaps.put("SHA1withRSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA1));
+        signatureAlgsMaps.put("SHA256withRSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256));
         signatureAlgsMaps.put("DSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_DSA));
-        signatureAlgsMaps.put("RSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256));
+        signatureAlgsMaps.put("RSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA));
     }
 
     @Override

--- a/src/main/java/xades4j/providers/impl/DefaultAlgorithmsProviderEx.java
+++ b/src/main/java/xades4j/providers/impl/DefaultAlgorithmsProviderEx.java
@@ -30,7 +30,7 @@ import xades4j.providers.AlgorithmsProviderEx;
  * The default implementation of {@link AlgorithmsProviderEx}. The defaults
  * are:
  * <ul>
- *  <li>Signature: RSA(RSA_SHA256), DSA(DSA_SHA1)</li>
+ *  <li>Signature: RSA(RSA_SHA256, RSA_SHA1), DSA(DSA_SHA1)</li>
  *  <li>Canonicalization: Canonical XML 1.0 without comments</li>
  *  <li>Digest: SHA256 (data objs and refs properties); SHA1 (time-stamps)</li>
  * </ul>
@@ -43,14 +43,17 @@ public class DefaultAlgorithmsProviderEx implements AlgorithmsProviderEx
     static
     {
         signatureAlgsMaps = new HashMap<String, Algorithm>(2);
+        signatureAlgsMaps.put("SHA1withRSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA1));
+        signatureAlgsMaps.put("SHA256withRSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256));
         signatureAlgsMaps.put("DSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_DSA));
-        signatureAlgsMaps.put("RSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256));
+        signatureAlgsMaps.put("RSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA));
     }
 
     @Override
     public Algorithm getSignatureAlgorithm(String keyAlgorithmName) throws UnsupportedAlgorithmException
     {
         Algorithm sigAlg = signatureAlgsMaps.get(keyAlgorithmName);
+
         if (null == sigAlg)
         {
             throw new UnsupportedAlgorithmException("Signature algorithm not supported by the provider", keyAlgorithmName);

--- a/src/main/java/xades4j/providers/impl/DefaultAlgorithmsProviderEx.java
+++ b/src/main/java/xades4j/providers/impl/DefaultAlgorithmsProviderEx.java
@@ -43,10 +43,8 @@ public class DefaultAlgorithmsProviderEx implements AlgorithmsProviderEx
     static
     {
         signatureAlgsMaps = new HashMap<String, Algorithm>(2);
-        signatureAlgsMaps.put("SHA1withRSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA1));
-        signatureAlgsMaps.put("SHA256withRSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256));
         signatureAlgsMaps.put("DSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_DSA));
-        signatureAlgsMaps.put("RSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA));
+        signatureAlgsMaps.put("RSA", new GenericAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256));
     }
 
     @Override

--- a/src/main/java/xades4j/verification/SignatureUtils.java
+++ b/src/main/java/xades4j/verification/SignatureUtils.java
@@ -88,19 +88,19 @@ class SignatureUtils
         // "All certificates appearing in an X509Data element MUST relate to the
         // validation key by either containing it or being part of a certification
         // chain that terminates in a certificate containing the validation key".
-        
+
         // Scan ds:X509Data to find ds:IssuerSerial or ds:SubjectName elements. The
         // first to be found is used to select the leaf certificate. If none of those
         // elements is present, the first ds:X509Certificate is assumed as the signing
         // certificate.
         boolean hasSelectionCriteria = false;
-        
+
         try
         {
             for (int i = 0; i < keyInfo.lengthX509Data(); ++i)
             {
                 X509Data x509Data = keyInfo.itemX509Data(i);
-                
+
                 if(!hasSelectionCriteria)
                 {
                     if (x509Data.containsIssuerSerial())
@@ -116,7 +116,7 @@ class SignatureUtils
                         hasSelectionCriteria = true;
                     }
                 }
-                
+
                 // Collect all certificates as they may be needed to build the cert path.
                 if (x509Data.containsCertificate())
                 {
@@ -126,7 +126,7 @@ class SignatureUtils
                     }
                 }
             }
-            
+
             if(!hasSelectionCriteria)
             {
                 if(keyInfoCerts.isEmpty())
@@ -137,7 +137,7 @@ class SignatureUtils
                     throw new InvalidKeyInfoDataException("No criteria to select the leaf certificate");
                 }
                 certSelector.setCertificate(keyInfoCerts.get(0));
-            }           
+            }
         }
         catch (XMLSecurityException ex)
         {
@@ -331,7 +331,10 @@ class SignatureUtils
 
         try
         {
-            Node sPropsNode = signedPropsRef.getNodesetBeforeFirstCanonicalization().getSubNode();
+            // Node sPropsNode = signedPropsRef.getNodesetBeforeFirstCanonicalization().getSubNode();
+            // FIXME: Use line on top after xmlsec fixes issue SANTUARIO-462, probably on the 2.0.9 release
+            // URL: https://issues.apache.org/jira/browse/SANTUARIO-462
+            Node sPropsNode = signedPropsRef.getContentsBeforeTransformation().getSubNode();
             if (sPropsNode == null || sPropsNode.getNodeType() != Node.ELEMENT_NODE)
             {
                 throw new QualifyingPropertiesIncorporationException("The supposed reference over signed properties doesn't cover an element.");

--- a/src/main/java/xades4j/verification/XadesVerifier.java
+++ b/src/main/java/xades4j/verification/XadesVerifier.java
@@ -62,6 +62,31 @@ public interface XadesVerifier
             SignatureSpecificVerificationOptions verificationOptions) throws XAdES4jException;
 
     /**
+     * Verifies a signature.
+     * @param signatureElem the element containing the signature; must have an Id
+     * @param verificationOptions signature verification options. If {@code null},
+     *      default options are used
+     * @param secureValidation boolean value. If true, it will perform the digital
+     *      enforcing the following restrictions:
+     *           1. Forbids use of the XSLT Transform
+     *           2. Restricts the number of SignedInfo or Manifest References to 30 or less
+     *           3. Restricts the number of Reference Transforms to 5 or less
+     *           4. Forbids the use of MD5 related signature or mac algorithms
+     *           5. Ensures that Reference Ids are unique to help prevent signature wrapping attacks
+     *           6. Forbids Reference URIs of type http or file
+     *           7. Does not allow a RetrievalMethod to reference another RetrievalMethod
+     * @return the verification result
+     *
+     * @see xades4j.verification.SignatureSpecificVerificationOptions
+     * @throws XAdES4jException if an error occurs, including if signature verification fails
+     * @throws NullPointerException if {@code signatureElem} is {@code null}
+     */
+    public XAdESVerificationResult verify(
+            Element signatureElem,
+            SignatureSpecificVerificationOptions verificationOptions,
+            boolean secureValidation) throws XAdES4jException;
+
+    /**
      * Verifies a signature and extends its format if needed.
      * <p>
      * Note that, due to the library's internal design, the properties being added

--- a/src/main/java/xades4j/verification/XadesVerifierImpl.java
+++ b/src/main/java/xades4j/verification/XadesVerifierImpl.java
@@ -102,6 +102,12 @@ class XadesVerifierImpl implements XadesVerifier
     @Override
     public XAdESVerificationResult verify(Element signatureElem, SignatureSpecificVerificationOptions verificationOptions) throws XAdES4jException
     {
+        return this.verify(signatureElem, verificationOptions, false);
+    }
+
+    @Override
+    public XAdESVerificationResult verify(Element signatureElem, SignatureSpecificVerificationOptions verificationOptions, boolean secureValidation) throws XAdES4jException
+    {
         if (null == signatureElem)
         {
             throw new NullPointerException("Signature node not specified");
@@ -117,7 +123,7 @@ class XadesVerifierImpl implements XadesVerifier
         XMLSignature signature;
         try
         {
-            signature = new XMLSignature(signatureElem, verificationOptions.getBaseUri());
+            signature = new XMLSignature(signatureElem, verificationOptions.getBaseUri(), secureValidation);
         } catch (XMLSecurityException ex)
         {
             throw new UnmarshalException("Bad XML signature", ex);
@@ -132,7 +138,7 @@ class XadesVerifierImpl implements XadesVerifier
         ReferencesRes referencesRes = SignatureUtils.processReferences(signature);
 
         /* Apply early verifiers */
-        
+
         RawSignatureVerifierContext rawCtx = new RawSignatureVerifierContext(signature);
         for (RawSignatureVerifier rawSignatureVerifier : this.rawSigVerifiers)
         {
@@ -217,7 +223,7 @@ class XadesVerifierImpl implements XadesVerifier
 
         return res;
     }
-    
+
     /*************************************************************************************/
     /**/
 

--- a/src/test/java/xades4j/production/TestAlgorithmsProvider.java
+++ b/src/test/java/xades4j/production/TestAlgorithmsProvider.java
@@ -20,6 +20,8 @@ package xades4j.production;
 import org.apache.xml.security.algorithms.MessageDigestAlgorithm;
 import xades4j.algorithms.Algorithm;
 import xades4j.UnsupportedAlgorithmException;
+import xades4j.algorithms.CanonicalXMLWithoutComments;
+import xades4j.algorithms.GenericAlgorithm;
 import xades4j.providers.AlgorithmsProviderEx;
 
 /**
@@ -37,7 +39,7 @@ class TestAlgorithmsProvider implements AlgorithmsProviderEx{
     @Override
     public Algorithm getCanonicalizationAlgorithmForSignature()
     {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return new CanonicalXMLWithoutComments();
     }
 
     @Override


### PR DESCRIPTION
Changes related to issue #108.

Make sure you merge #111 before this one since this one builds on top of it.

This will enable the extraction of the Signature Algorithm Field directly from the Signing Certificate. It helps to generalize the signing procedures allowing any certificate (as long as the mapping exists).

This is the last feature.