### PR TITLE
Provide the option to include the full certificate chain in ds:KeyInfo

### DIFF
--- a/src/main/java/xades4j/production/SignerBES.java
+++ b/src/main/java/xades4j/production/SignerBES.java
@@ -179,7 +179,7 @@ class SignerBES implements XadesSigner
                 signature);
         
         /* ds:KeyInfo */
-        this.keyInfoBuilder.buildKeyInfo(signingCertificate, signature);
+        this.keyInfoBuilder.buildKeyInfo(signingCertificateChain, signature);
 
         /* QualifyingProperties element */
         // Create the QualifyingProperties element

--- a/src/main/java/xades4j/providers/BasicSignatureOptionsProvider.java
+++ b/src/main/java/xades4j/providers/BasicSignatureOptionsProvider.java
@@ -35,6 +35,14 @@ public interface BasicSignatureOptionsProvider
     boolean includeSigningCertificate();
 
     /**
+     * Indicates whether the full certificate chain should be included in
+     * {@code ds:X509Certificate} elements inside the same {@code ds:X509Data} within
+     * {@code ds:KeyInfo}.
+     * @return {@code true} if the full chain should be included; false otherwise
+     */
+    boolean includeSigningCertificateFullChain();
+
+    /**
      * Indicates whether a {@code ds:KeyValue} element containing the public key's
      * value should be included in {@code ds:KeyInfo}.
      * @return {@code true} if the public key should be included; false otherwise

--- a/src/main/java/xades4j/providers/impl/DefaultBasicSignatureOptionsProvider.java
+++ b/src/main/java/xades4j/providers/impl/DefaultBasicSignatureOptionsProvider.java
@@ -23,6 +23,7 @@ import xades4j.providers.BasicSignatureOptionsProvider;
  * are:
  * <ul>
  *  <li>includeSigningCertificate: true</li>
+ *  <li>includeSigningCertificateFullChain: false</li>
  *  <li>includePublicKey: false</li>
  *  <li>signSigningCertificate: false</li>
  * </ul>
@@ -31,19 +32,22 @@ import xades4j.providers.BasicSignatureOptionsProvider;
 public class DefaultBasicSignatureOptionsProvider implements BasicSignatureOptionsProvider
 {
     private final boolean includeSigningCertificate;
+    private final boolean includeSigningCertificateFullChain;
     private final boolean includePublicKey;
     private final boolean signSigningCertificate;
 
     public DefaultBasicSignatureOptionsProvider()
     {
         this.includeSigningCertificate = true;
+        this.includeSigningCertificateFullChain = false;
         this.includePublicKey = false;
         this.signSigningCertificate = false;
     }
 
-    public DefaultBasicSignatureOptionsProvider(boolean includeSigningCertificate, boolean includePublicKey, boolean signSigningCertificate)
+    public DefaultBasicSignatureOptionsProvider(boolean includeSigningCertificate, boolean includeSigningCertificateFullChain, boolean includePublicKey, boolean signSigningCertificate)
     {
         this.includeSigningCertificate = includeSigningCertificate;
+        this.includeSigningCertificateFullChain = includeSigningCertificateFullChain;
         this.includePublicKey = includePublicKey;
         this.signSigningCertificate = signSigningCertificate;
     }
@@ -52,6 +56,11 @@ public class DefaultBasicSignatureOptionsProvider implements BasicSignatureOptio
     public boolean includeSigningCertificate()
     {
         return this.includeSigningCertificate;
+    }
+
+    @Override
+    public boolean includeSigningCertificateFullChain() {
+        return this.includeSigningCertificateFullChain;
     }
 
     @Override

--- a/src/test/java/xades4j/production/KeyInfoBuilderTest.java
+++ b/src/test/java/xades4j/production/KeyInfoBuilderTest.java
@@ -19,6 +19,8 @@ package xades4j.production;
 import java.io.FileInputStream;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
+
 import junit.framework.Assert;
 import org.apache.xml.security.keys.content.KeyValue;
 import org.apache.xml.security.keys.content.x509.XMLX509Certificate;
@@ -42,12 +44,14 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
     {
 
         private final boolean includeSigningCertificate;
+        private final boolean includeSigningCertificateFullChain;
         private final boolean includePublicKey;
         private final boolean signSigningCertificate;
 
-        public TestBasicSignatureOptionsProvider(boolean includeSigningCertificate, boolean includePublicKey, boolean signSigningCertificate)
+        public TestBasicSignatureOptionsProvider(boolean includeSigningCertificate, boolean includeSigningCertificateFullChain, boolean includePublicKey, boolean signSigningCertificate)
         {
             this.includeSigningCertificate = includeSigningCertificate;
+            this.includeSigningCertificateFullChain = includeSigningCertificateFullChain;
             this.includePublicKey = includePublicKey;
             this.signSigningCertificate = signSigningCertificate;
         }
@@ -56,6 +60,11 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         public boolean includeSigningCertificate()
         {
             return this.includeSigningCertificate;
+        }
+
+        @Override
+        public boolean includeSigningCertificateFullChain() {
+            return includeSigningCertificateFullChain;
         }
 
         @Override
@@ -88,12 +97,12 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         System.out.println("includeCertAndKey");
 
         KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new TestBasicSignatureOptionsProvider(true, true, false),
+                new TestBasicSignatureOptionsProvider(true, false, true, false),
                 new TestAlgorithmsProvider(),
                 new TestAlgorithmsParametersMarshallingProvider());
         XMLSignature xmlSignature = getTestSignature();
 
-        keyInfoBuilder.buildKeyInfo(testCertificate, xmlSignature);
+        keyInfoBuilder.buildKeyInfo(Collections.singletonList(testCertificate), xmlSignature);
 
         Assert.assertEquals(0, xmlSignature.getSignedInfo().getLength());
 
@@ -110,12 +119,12 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         System.out.println("ignoreSignSigningCertificateIfNotIncluded");
 
         KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new TestBasicSignatureOptionsProvider(false, true, true),
+                new TestBasicSignatureOptionsProvider(false, false, true, true),
                 new TestAlgorithmsProvider(),
                 new TestAlgorithmsParametersMarshallingProvider());
         XMLSignature xmlSignature = getTestSignature();
 
-        keyInfoBuilder.buildKeyInfo(testCertificate, xmlSignature);
+        keyInfoBuilder.buildKeyInfo(Collections.singletonList(testCertificate), xmlSignature);
 
         Assert.assertEquals(0, xmlSignature.getSignedInfo().getLength());
 
@@ -131,12 +140,12 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         System.out.println("signSigningCertificateIfIncluded");
 
         KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new TestBasicSignatureOptionsProvider(true, true, true),
+                new TestBasicSignatureOptionsProvider(true, false, true, true),
                 new TestAlgorithmsProvider(),
                 new TestAlgorithmsParametersMarshallingProvider());
         XMLSignature xmlSignature = getTestSignature();
 
-        keyInfoBuilder.buildKeyInfo(testCertificate, xmlSignature);
+        keyInfoBuilder.buildKeyInfo(Collections.singletonList(testCertificate), xmlSignature);
 
         SignedInfo signedInfo = xmlSignature.getSignedInfo();
         Assert.assertEquals(1, signedInfo.getLength());
@@ -146,6 +155,8 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
 
         Assert.assertEquals(1, xmlSignature.getKeyInfo().lengthX509Data());
     }
+
+    // TODO create a new test for the full certificate chain being included in KeyInfo (BasicSignatureOptionsProvider.includeSigningCertificateFullChain).
 
     private XMLSignature getTestSignature() throws Exception
     {


### PR DESCRIPTION
This would allow to include the full certificate chain in `ds:KeyInfo`, so if you want to include the full certificate chain you don't require to go up to XAdES-X-L.

Pending issues: 

- It haven't been tested yet if XAdES-X-L would duplicate certificates in `ds:KeyInfo`.
- Tests haven't been written yet.