### PR TITLE
Add disableSubjectName and disable IssuerSerial in ds:KeyInfo Element

### DIFF
--- a/src/main/java/xades4j/production/KeyInfoBuilder.java
+++ b/src/main/java/xades4j/production/KeyInfoBuilder.java
@@ -28,6 +28,7 @@ import xades4j.UnsupportedAlgorithmException;
 import xades4j.algorithms.Algorithm;
 import xades4j.providers.AlgorithmsProviderEx;
 import xades4j.providers.BasicSignatureOptionsProvider;
+import xades4j.providers.ExtendedBasicSignatureOptionsProvider;
 import xades4j.utils.CanonicalizerUtils;
 import xades4j.utils.TransformUtils;
 import xades4j.xml.marshalling.algorithms.AlgorithmsParametersMarshallingProvider;
@@ -83,14 +84,20 @@ class KeyInfoBuilder
             {
                 X509Data x509Data = new X509Data(xmlSig.getDocument());
                 x509Data.addCertificate(signingCertificate);
-                
-                if(!this.basicSignatureOptionsProvider.disableSubjectName()) {
+                if ( this.basicSignatureOptionsProvider instanceof ExtendedBasicSignatureOptionsProvider) {
+	            	 if(!(((ExtendedBasicSignatureOptionsProvider) this.basicSignatureOptionsProvider).disableSubjectName())) {
+	                 	x509Data.addSubjectName(RfcUtils.toRfc4514(signingCertificate.getSubjectX500Principal()));
+	                 }
+	                 
+	                 if(!(((ExtendedBasicSignatureOptionsProvider) this.basicSignatureOptionsProvider).disableIssuerSerial())) {
+	                 	x509Data.addIssuerSerial(RfcUtils.toRfc4514(signingCertificate.getIssuerX500Principal()), signingCertificate.getSerialNumber());
+	                 }
+                 }
+                else {
                 	x509Data.addSubjectName(RfcUtils.toRfc4514(signingCertificate.getSubjectX500Principal()));
-                }
-                
-                if(!this.basicSignatureOptionsProvider.disableIssuerSerial()) {
                 	x509Data.addIssuerSerial(RfcUtils.toRfc4514(signingCertificate.getIssuerX500Principal()), signingCertificate.getSerialNumber());
                 }
+                
                 
                 xmlSig.getKeyInfo().add(x509Data);
 

--- a/src/main/java/xades4j/production/KeyInfoBuilder.java
+++ b/src/main/java/xades4j/production/KeyInfoBuilder.java
@@ -83,8 +83,15 @@ class KeyInfoBuilder
             {
                 X509Data x509Data = new X509Data(xmlSig.getDocument());
                 x509Data.addCertificate(signingCertificate);
-                x509Data.addSubjectName(RfcUtils.toRfc4514(signingCertificate.getSubjectX500Principal()));
-                x509Data.addIssuerSerial(RfcUtils.toRfc4514(signingCertificate.getIssuerX500Principal()), signingCertificate.getSerialNumber());
+                
+                if(!this.basicSignatureOptionsProvider.disableSubjectName()) {
+                	x509Data.addSubjectName(RfcUtils.toRfc4514(signingCertificate.getSubjectX500Principal()));
+                }
+                
+                if(!this.basicSignatureOptionsProvider.disableIssuerSerial()) {
+                	x509Data.addIssuerSerial(RfcUtils.toRfc4514(signingCertificate.getIssuerX500Principal()), signingCertificate.getSerialNumber());
+                }
+                
                 xmlSig.getKeyInfo().add(x509Data);
 
                 if (this.basicSignatureOptionsProvider.signSigningCertificate())

--- a/src/main/java/xades4j/providers/BasicSignatureOptionsProvider.java
+++ b/src/main/java/xades4j/providers/BasicSignatureOptionsProvider.java
@@ -48,4 +48,27 @@ public interface BasicSignatureOptionsProvider
      * @return {@code true} if the certificate should be signed; false otherwise
      */
     boolean signSigningCertificate();
+    
+    
+    /**
+     * Disable {@code ds:X509SubjectName} in {@code ds:X509Certificate} 
+     * element containing the signing certificate. This is only considered if
+     * {@link #includeSigningCertificate()} returns {@code true}. 
+     * Default method for backwards compatibility
+     * @return {@code true} if the subjectName  should be disabled; false otherwise
+     */
+    default boolean disableSubjectName() {
+    	return false;
+    }
+    
+    /**
+     * Disable {@code ds:X509IssuerSerial} in {@code ds:X509Certificate} 
+     * element containing the signing certificate. This is only considered if
+     * {@link #includeSigningCertificate()} returns {@code true}. 
+     * Default method for backwards compatibility
+     * @return {@code true} if the subjectName  should be disabled; false otherwise
+     */
+    default boolean disableIssuerSerial() {
+    	return false;
+    }
 }

--- a/src/main/java/xades4j/providers/ExtendedBasicSignatureOptionsProvider.java
+++ b/src/main/java/xades4j/providers/ExtendedBasicSignatureOptionsProvider.java
@@ -14,41 +14,36 @@
  * You should have received a copy of the GNU Lesser General Public License along
  * with XAdES4j. If not, see <http://www.gnu.org/licenses/>.
  */
+
 package xades4j.providers;
 
 /**
- * Provides basic signature options such as whether {@code ds:KeyInfo} elements
+ * Provides an extension for basic signature options such as whether {@code ds:KeyInfo} elements
  * should be included.
  *
  * A default implementation is provided.
  * @see xades4j.providers.impl.DefaultBasicSignatureOptionsProvider
  * 
- * @author Luís
+ * @author Ismael
  */
-public interface BasicSignatureOptionsProvider
-{
-    /**
-     * Indicates whether the signing certificate, the subject name and issuer/serial
-     * should be included within {@code ds:KeyInfo}.
-     * @return {@code true} if the certificate should be included; false otherwise
-     */
-    boolean includeSigningCertificate();
 
-    /**
-     * Indicates whether a {@code ds:KeyValue} element containing the public key's
-     * value should be included in {@code ds:KeyInfo}.
-     * @return {@code true} if the public key should be included; false otherwise
-     */
-    boolean includePublicKey();
 
+public interface ExtendedBasicSignatureOptionsProvider extends BasicSignatureOptionsProvider{
+	
+	 /**
+     * Disable {@code ds:X509SubjectName} in {@code ds:X509Certificate} 
+     * element containing the signing certificate. This is only considered if
+     * {@link #includeSigningCertificate()} returns {@code true}. 
+     * @return {@code true} if the subjectName  should be disabled; false otherwise
+     */
+     boolean disableSubjectName();
+    
     /**
-     * Indicates whether the signature should cover the {@code ds:X509Certificate}
+     * Disable {@code ds:X509IssuerSerial} in {@code ds:X509Certificate} 
      * element containing the signing certificate. This is only considered if
      * {@link #includeSigningCertificate()} returns {@code true}.
-     * @return {@code true} if the certificate should be signed; false otherwise
+     * @return {@code true} if the subjectName  should be disabled; false otherwise
      */
-    boolean signSigningCertificate();
-    
-    
-   
+     boolean disableIssuerSerial();
+
 }


### PR DESCRIPTION
I need to eliminate ds:SubjectName and ds:IssuerSerial nodes in the generation of XADES-EPES signatures