### PR TITLE
Refactor basic signature options

### DIFF
--- a/src/main/java/xades4j/production/BasicSignatureOptions.java
+++ b/src/main/java/xades4j/production/BasicSignatureOptions.java
@@ -28,7 +28,7 @@ public final class BasicSignatureOptions
     private boolean includeSubjectName;
     private boolean includeIssuerSerial;
     private boolean includePublicKey;
-    private boolean signSigningCertificate;
+    private boolean signKeyInfo;
 
     /**
      * Configures whether the signing certificate should be included in {@code ds:KeyInfo}.
@@ -95,24 +95,19 @@ public final class BasicSignatureOptions
         return this.includePublicKey;
     }
     /**
-     * Configures whether the signature should cover the
-     * {@code ds:X509Certificate} element containing the signing certificate.
-     * 
-     * This is only considered if {@link #includeSigningCertificate()} returns
-     * {@code true}.
+     * Configures whether the signature should cover the {@code ds:KeyInfo} element.
      *
-     * @param signSigningCertificate {@code true} if the certificate should be
-     * signed; false otherwise
+     * @param signKeyInfo {@code true} if the {@code ds:KeyInfo} should be signed; false otherwise
      * @return the current instance
      */
-    public BasicSignatureOptions signSigningCertificate(boolean signSigningCertificate)
+    public BasicSignatureOptions signKeyInfo(boolean signKeyInfo)
     {
-        this.signSigningCertificate = signSigningCertificate;
+        this.signKeyInfo = signKeyInfo;
         return this;
     }
 
-    boolean signSigningCertificate()
+    boolean signKeyInfo()
     {
-        return this.signSigningCertificate;
+        return this.signKeyInfo;
     }
 }

--- a/src/main/java/xades4j/production/BasicSignatureOptions.java
+++ b/src/main/java/xades4j/production/BasicSignatureOptions.java
@@ -1,0 +1,118 @@
+/*
+ * XAdES4j - A Java library for generation and verification of XAdES signatures.
+ * Copyright (C) 2018 Luis Goncalves.
+ * 
+ * XAdES4j is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or any later version.
+ * 
+ * XAdES4j is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with XAdES4j. If not, see <http://www.gnu.org/licenses/>.
+ */
+package xades4j.production;
+
+/**
+ * Configuration of basic signature options such as whether {@code ds:KeyInfo}
+ * elements should be included.
+ *
+ * @author luis
+ */
+public final class BasicSignatureOptions
+{
+    private boolean includeSigningCertificate;
+    private boolean includeSubjectName;
+    private boolean includeIssuerSerial;
+    private boolean includePublicKey;
+    private boolean signSigningCertificate;
+
+    /**
+     * Configures whether the signing certificate should be included in {@code ds:KeyInfo}.
+     * @param includeSigningCertificate {@code true} if the certificate should be included; false otherwise
+     * @return the current instance
+     */
+    public BasicSignatureOptions includeSigningCertificate(boolean includeSigningCertificate)
+    {
+        this.includeSigningCertificate = includeSigningCertificate;
+        return this;
+    }
+    
+    boolean includeSigningCertificate()
+    {
+        return this.includeSigningCertificate;
+    }
+
+    /**
+     * Configures whether the subject name should be included in {@code ds:KeyInfo}.
+     * @param includeSubjectName {@code true} if the subject name should be included; false otherwise
+     * @return the current instance
+     */
+    public BasicSignatureOptions includeSubjectName(boolean includeSubjectName)
+    {
+        this.includeSubjectName = includeSubjectName;
+        return this;
+    }
+
+    boolean includeSubjectName()
+    {
+        return this.includeSubjectName;
+    }
+
+    /**
+     * Configures whether the issuer/serial should be included in {@code ds:KeyInfo}.
+     * @param includeIssuerSerial {@code true} if the issuer/serial should be included; false otherwise
+     * @return the current instance
+     */
+    public BasicSignatureOptions includeIssuerSerial(boolean includeIssuerSerial)
+    {
+        this.includeIssuerSerial = includeIssuerSerial;
+        return this;
+    }
+    
+    boolean includeIssuerSerial()
+    {
+        return this.includeIssuerSerial;
+    }
+
+    /**
+     * Configures whether a {@code ds:KeyValue} element containing the public key's
+     * value should be included in {@code ds:KeyInfo}.
+     * @param includePublicKey {@code true} if the public key should be included; false otherwise
+     * @return the current instance
+     */
+    public BasicSignatureOptions includePublicKey(boolean includePublicKey)
+    {
+        this.includePublicKey = includePublicKey;
+        return this;
+    }
+    
+    boolean includePublicKey()
+    {
+        return this.includePublicKey;
+    }
+    /**
+     * Configures whether the signature should cover the
+     * {@code ds:X509Certificate} element containing the signing certificate.
+     * 
+     * This is only considered if {@link #includeSigningCertificate()} returns
+     * {@code true}.
+     *
+     * @param signSigningCertificate {@code true} if the certificate should be
+     * signed; false otherwise
+     * @return the current instance
+     */
+    public BasicSignatureOptions signSigningCertificate(boolean signSigningCertificate)
+    {
+        this.signSigningCertificate = signSigningCertificate;
+        return this;
+    }
+
+    boolean signSigningCertificate()
+    {
+        return this.signSigningCertificate;
+    }
+}

--- a/src/main/java/xades4j/production/BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter.java
+++ b/src/main/java/xades4j/production/BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter.java
@@ -1,0 +1,49 @@
+/*
+ * XAdES4j - A Java library for generation and verification of XAdES signatures.
+ * Copyright (C) 2018 Luis Goncalves.
+ * 
+ * XAdES4j is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or any later version.
+ * 
+ * XAdES4j is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with XAdES4j. If not, see <http://www.gnu.org/licenses/>.
+ */
+package xades4j.production;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import xades4j.providers.BasicSignatureOptionsProvider;
+
+/**
+ * Adapts the old {@link xades4j.providers.BasicSignatureOptionsProvider} to the
+ * new {@link BasicSignatureOptions} class.
+ * 
+ * @author luis
+ */
+final class BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter implements Provider<BasicSignatureOptions>
+{
+    private final BasicSignatureOptionsProvider provider;
+    
+    @Inject
+    BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter(BasicSignatureOptionsProvider provider)
+    {
+        this.provider = provider;
+    }
+
+    @Override
+    public BasicSignatureOptions get()
+    {
+        return new BasicSignatureOptions()
+                .includeSigningCertificate(this.provider.includeSigningCertificate())
+                .includeSubjectName(this.provider.includeSigningCertificate())
+                .includeIssuerSerial(this.provider.includeSigningCertificate())
+                .includePublicKey(this.provider.includePublicKey())
+                .signSigningCertificate(this.provider.signSigningCertificate());
+    }
+}

--- a/src/main/java/xades4j/production/BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter.java
+++ b/src/main/java/xades4j/production/BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter.java
@@ -44,6 +44,6 @@ final class BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter implements
                 .includeSubjectName(this.provider.includeSigningCertificate())
                 .includeIssuerSerial(this.provider.includeSigningCertificate())
                 .includePublicKey(this.provider.includePublicKey())
-                .signSigningCertificate(this.provider.signSigningCertificate());
+                .signKeyInfo(this.provider.signSigningCertificate());
     }
 }

--- a/src/main/java/xades4j/production/DefaultProductionBindingsModule.java
+++ b/src/main/java/xades4j/production/DefaultProductionBindingsModule.java
@@ -81,6 +81,8 @@ class DefaultProductionBindingsModule extends AbstractModule
         // Will wrap the AlgorithmsProviderEx in use
         bind(AlgorithmsProvider.class).to(AlgorithmsProvider_ExToDeprecated_Adapter.class);
         bind(BasicSignatureOptionsProvider.class).to(DefaultBasicSignatureOptionsProvider.class);
+        // Will adapt from the BasicSignatureOptionsProvider in use
+        bind(BasicSignatureOptions.class).toProvider(BasicSignatureOptionsProvider_DeprecatedToOptions_Adapter.class);
         bind(MessageDigestEngineProvider.class).to(DefaultMessageDigestProvider.class);
         bind(X500NameStyleProvider.class).to(DefaultX500NameStyleProvider.class);
         bind(TimeStampTokenProvider.class).to(HttpTimeStampTokenProvider.class);

--- a/src/main/java/xades4j/production/KeyInfoBuilder.java
+++ b/src/main/java/xades4j/production/KeyInfoBuilder.java
@@ -27,7 +27,6 @@ import org.apache.xml.security.transforms.Transforms;
 import xades4j.UnsupportedAlgorithmException;
 import xades4j.algorithms.Algorithm;
 import xades4j.providers.AlgorithmsProviderEx;
-import xades4j.providers.BasicSignatureOptionsProvider;
 import xades4j.providers.X500NameStyleProvider;
 import xades4j.utils.CanonicalizerUtils;
 import xades4j.utils.TransformUtils;
@@ -40,19 +39,18 @@ import xades4j.xml.marshalling.algorithms.AlgorithmsParametersMarshallingProvide
  */
 class KeyInfoBuilder
 {
-
-    private final BasicSignatureOptionsProvider basicSignatureOptionsProvider;
+    private final BasicSignatureOptions basicSignatureOptions;
     private final AlgorithmsProviderEx algorithmsProvider;
     private final AlgorithmsParametersMarshallingProvider algorithmsParametersMarshaller;
     private final X500NameStyleProvider x500NameStyleProvider;
 
     KeyInfoBuilder(
-            BasicSignatureOptionsProvider basicSignatureOptionsProvider,
+            BasicSignatureOptions basicSignatureOptions,
             AlgorithmsProviderEx algorithmsProvider,
             AlgorithmsParametersMarshallingProvider algorithmsParametersMarshaller,
             X500NameStyleProvider x500NameStyleProvider)
     {
-        this.basicSignatureOptionsProvider = basicSignatureOptionsProvider;
+        this.basicSignatureOptions = basicSignatureOptions;
         this.algorithmsProvider = algorithmsProvider;
         this.algorithmsParametersMarshaller = algorithmsParametersMarshaller;
         this.x500NameStyleProvider = x500NameStyleProvider;
@@ -80,7 +78,7 @@ class KeyInfoBuilder
             throw new SigningCertValidityException(signingCertificate);
         }
 
-        if (this.basicSignatureOptionsProvider.includeSigningCertificate())
+        if (this.basicSignatureOptions.includeSigningCertificate())
         {
             try
             {
@@ -90,7 +88,7 @@ class KeyInfoBuilder
                 x509Data.addIssuerSerial(this.x500NameStyleProvider.toString(signingCertificate.getIssuerX500Principal()), signingCertificate.getSerialNumber());
                 xmlSig.getKeyInfo().add(x509Data);
 
-                if (this.basicSignatureOptionsProvider.signSigningCertificate())
+                if (this.basicSignatureOptions.signSigningCertificate())
                 {
                     String keyInfoId = xmlSig.getId() + "-keyinfo";
                     xmlSig.getKeyInfo().setId(keyInfoId);
@@ -116,7 +114,7 @@ class KeyInfoBuilder
             }
         }
 
-        if (this.basicSignatureOptionsProvider.includePublicKey())
+        if (this.basicSignatureOptions.includePublicKey())
         {
             xmlSig.addKeyInfo(signingCertificate.getPublicKey());
         }

--- a/src/main/java/xades4j/production/KeyInfoBuilder.java
+++ b/src/main/java/xades4j/production/KeyInfoBuilder.java
@@ -92,38 +92,18 @@ class KeyInfoBuilder
                 try
                 {
                     x509Data.addCertificate(signingCertificate);
-
-                    if (this.basicSignatureOptions.signSigningCertificate())
-                    {
-                        String keyInfoId = xmlSig.getId() + "-keyinfo";
-                        xmlSig.getKeyInfo().setId(keyInfoId);
-
-                        // Use same canonicalization URI as specified in the ds:CanonicalizationMethod for Signature.
-                        Algorithm canonAlg = this.algorithmsProvider.getCanonicalizationAlgorithmForSignature();
-                        CanonicalizerUtils.checkC14NAlgorithm(canonAlg);
-                        Transforms transforms = TransformUtils.createTransforms(canonAlg, this.algorithmsParametersMarshaller, xmlSig.getDocument());
-
-                        xmlSig.addDocument(
-                                '#' + keyInfoId,
-                                transforms,
-                                this.algorithmsProvider.getDigestAlgorithmForDataObjsReferences());
-                    }
-                } catch (XMLSignatureException ex)
-                {
-                    throw new UnsupportedAlgorithmException(
-                        "Digest algorithm not supported in the XML Signature provider",
-                        this.algorithmsProvider.getDigestAlgorithmForDataObjsReferences(), ex);
-                } catch (XMLSecurityException ex)
+                } 
+                catch (XMLSecurityException ex)
                 {
                     throw new KeyingDataException(ex.getMessage(), ex);
                 }
             }
-            
+
             if (this.basicSignatureOptions.includeIssuerSerial())
             {
                 x509Data.addIssuerSerial(this.x500NameStyleProvider.toString(signingCertificate.getIssuerX500Principal()), signingCertificate.getSerialNumber());
             }
-            
+
             if (this.basicSignatureOptions.includeSubjectName())
             {
                 x509Data.addSubjectName(this.x500NameStyleProvider.toString(signingCertificate.getSubjectX500Principal()));
@@ -133,6 +113,31 @@ class KeyInfoBuilder
         if (this.basicSignatureOptions.includePublicKey())
         {
             xmlSig.addKeyInfo(signingCertificate.getPublicKey());
+        }
+
+        if (this.basicSignatureOptions.signKeyInfo())
+        {
+            try
+            {
+                String keyInfoId = xmlSig.getId() + "-keyinfo";
+                xmlSig.getKeyInfo().setId(keyInfoId);
+
+                // Use same canonicalization URI as specified in the ds:CanonicalizationMethod for Signature.
+                Algorithm canonAlg = this.algorithmsProvider.getCanonicalizationAlgorithmForSignature();
+                CanonicalizerUtils.checkC14NAlgorithm(canonAlg);
+                Transforms transforms = TransformUtils.createTransforms(canonAlg, this.algorithmsParametersMarshaller, xmlSig.getDocument());
+
+                xmlSig.addDocument(
+                    '#' + keyInfoId,
+                    transforms,
+                    this.algorithmsProvider.getDigestAlgorithmForDataObjsReferences());
+            }
+            catch (XMLSignatureException ex)
+            {
+                throw new UnsupportedAlgorithmException(
+                    "Digest algorithm not supported in the XML Signature provider",
+                    this.algorithmsProvider.getDigestAlgorithmForDataObjsReferences(), ex);
+            }
         }
     }
 }

--- a/src/main/java/xades4j/production/SignerBES.java
+++ b/src/main/java/xades4j/production/SignerBES.java
@@ -16,9 +16,6 @@
  */
 package xades4j.production;
 
-import org.apache.xml.security.c14n.Canonicalizer;
-import org.apache.xml.security.c14n.InvalidCanonicalizerException;
-import org.apache.xml.security.transforms.TransformationException;
 import org.apache.xml.security.transforms.Transforms;
 import xades4j.properties.QualifyingProperties;
 import xades4j.properties.DataObjectDesc;
@@ -51,7 +48,6 @@ import xades4j.XAdES4jException;
 import xades4j.XAdES4jXMLSigException;
 import xades4j.properties.data.SigAndDataObjsPropertiesData;
 import xades4j.providers.AlgorithmsProviderEx;
-import xades4j.providers.BasicSignatureOptionsProvider;
 import xades4j.providers.DataObjectPropertiesProvider;
 import xades4j.providers.KeyingDataProvider;
 import xades4j.providers.SignaturePropertiesProvider;
@@ -94,7 +90,7 @@ class SignerBES implements XadesSigner
     protected SignerBES(
             KeyingDataProvider keyingProvider,
             AlgorithmsProviderEx algorithmsProvider,
-            BasicSignatureOptionsProvider basicSignatureOptionsProvider,
+            BasicSignatureOptions basicSignatureOptions,
             SignedDataObjectsProcessor dataObjectDescsProcessor,
             SignaturePropertiesProvider signaturePropsProvider,
             DataObjectPropertiesProvider dataObjPropsProvider,
@@ -105,9 +101,10 @@ class SignerBES implements XadesSigner
             X500NameStyleProvider x500NameStyleProvider)
     {
         if (ObjectUtils.anyNull(
-                keyingProvider, algorithmsProvider,
+                keyingProvider, algorithmsProvider, basicSignatureOptions,
                 signaturePropsProvider, dataObjPropsProvider, propsDataObjectsGenerator,
-                signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller))
+                signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller,
+                x500NameStyleProvider))
         {
             throw new NullPointerException("One or more arguments are null");
         }
@@ -121,7 +118,7 @@ class SignerBES implements XadesSigner
         this.x500NameStyleProvider = x500NameStyleProvider;
 
         this.dataObjectDescsProcessor = dataObjectDescsProcessor;
-        this.keyInfoBuilder = new KeyInfoBuilder(basicSignatureOptionsProvider, algorithmsProvider, algorithmsParametersMarshaller, x500NameStyleProvider);
+        this.keyInfoBuilder = new KeyInfoBuilder(basicSignatureOptions, algorithmsProvider, algorithmsParametersMarshaller, x500NameStyleProvider);
         this.qualifPropsProcessor = new QualifyingPropertiesProcessor(signaturePropsProvider, dataObjPropsProvider);
     }
 

--- a/src/main/java/xades4j/production/SignerC.java
+++ b/src/main/java/xades4j/production/SignerC.java
@@ -24,7 +24,6 @@ import xades4j.properties.SignedSignatureProperty;
 import xades4j.properties.UnsignedSignatureProperty;
 import xades4j.XAdES4jException;
 import xades4j.providers.AlgorithmsProviderEx;
-import xades4j.providers.BasicSignatureOptionsProvider;
 import xades4j.providers.DataObjectPropertiesProvider;
 import xades4j.providers.KeyingDataProvider;
 import xades4j.providers.SignaturePropertiesProvider;
@@ -49,7 +48,7 @@ class SignerC extends SignerT
     protected SignerC(
             KeyingDataProvider keyingProvider,
             AlgorithmsProviderEx algorithmsProvider,
-            BasicSignatureOptionsProvider basicSignatureOptionsProvider,
+            BasicSignatureOptions basicSignatureOptions,
             SignedDataObjectsProcessor dataObjectDescsProcessor,
             SignaturePropertiesProvider signaturePropsProvider,
             ValidationDataProvider validationDataProvider,
@@ -60,7 +59,7 @@ class SignerC extends SignerT
             AlgorithmsParametersMarshallingProvider algorithmsParametersMarshaller,
             X500NameStyleProvider x500NameStyleProvider)
     {
-        super(keyingProvider, algorithmsProvider, basicSignatureOptionsProvider, dataObjectDescsProcessor, signaturePropsProvider, dataObjPropsProvider, propsDataObjectsGenerator, signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller, x500NameStyleProvider);
+        super(keyingProvider, algorithmsProvider, basicSignatureOptions, dataObjectDescsProcessor, signaturePropsProvider, dataObjPropsProvider, propsDataObjectsGenerator, signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller, x500NameStyleProvider);
         if (null == validationDataProvider)
             throw new NullPointerException("ValidationDataProvider is null");
 

--- a/src/main/java/xades4j/production/SignerEPES.java
+++ b/src/main/java/xades4j/production/SignerEPES.java
@@ -24,7 +24,6 @@ import xades4j.properties.SignedSignatureProperty;
 import xades4j.properties.UnsignedSignatureProperty;
 import xades4j.XAdES4jException;
 import xades4j.providers.AlgorithmsProviderEx;
-import xades4j.providers.BasicSignatureOptionsProvider;
 import xades4j.providers.DataObjectPropertiesProvider;
 import xades4j.providers.KeyingDataProvider;
 import xades4j.providers.SignaturePolicyInfoProvider;
@@ -48,7 +47,7 @@ class SignerEPES extends SignerBES
     protected SignerEPES(
             KeyingDataProvider keyingProvider,
             AlgorithmsProviderEx algorithmsProvider,
-            BasicSignatureOptionsProvider basicSignatureOptionsProvider,
+            BasicSignatureOptions basicSignatureOptions,
             SignedDataObjectsProcessor dataObjectDescsProcessor,
             SignaturePolicyInfoProvider policyInfoProvider,
             SignaturePropertiesProvider signaturePropsProvider,
@@ -59,7 +58,7 @@ class SignerEPES extends SignerBES
             AlgorithmsParametersMarshallingProvider algorithmsParametersMarshaller,
             X500NameStyleProvider x500NameStyleProvider)
     {
-        super(keyingProvider, algorithmsProvider, basicSignatureOptionsProvider, dataObjectDescsProcessor, signaturePropsProvider, dataObjPropsProvider, propsDataObjectsGenerator, signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller, x500NameStyleProvider);
+        super(keyingProvider, algorithmsProvider, basicSignatureOptions, dataObjectDescsProcessor, signaturePropsProvider, dataObjPropsProvider, propsDataObjectsGenerator, signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller, x500NameStyleProvider);
         this.policyInfoProvider = policyInfoProvider;
     }
 

--- a/src/main/java/xades4j/production/SignerT.java
+++ b/src/main/java/xades4j/production/SignerT.java
@@ -24,7 +24,6 @@ import xades4j.properties.SignedSignatureProperty;
 import xades4j.properties.UnsignedSignatureProperty;
 import xades4j.XAdES4jException;
 import xades4j.providers.AlgorithmsProviderEx;
-import xades4j.providers.BasicSignatureOptionsProvider;
 import xades4j.providers.DataObjectPropertiesProvider;
 import xades4j.providers.KeyingDataProvider;
 import xades4j.providers.SignaturePolicyInfoProvider;
@@ -49,7 +48,7 @@ class SignerT extends SignerBES
     protected SignerT(
             KeyingDataProvider keyingProvider,
             AlgorithmsProviderEx algorithmsProvider,
-            BasicSignatureOptionsProvider basicSignatureOptionsProvider,
+            BasicSignatureOptions basicSignatureOptions,
             SignedDataObjectsProcessor dataObjectDescsProcessor,
             SignaturePropertiesProvider signaturePropsProvider,
             DataObjectPropertiesProvider dataObjPropsProvider,
@@ -59,7 +58,7 @@ class SignerT extends SignerBES
             AlgorithmsParametersMarshallingProvider algorithmsParametersMarshaller,
             X500NameStyleProvider x500NameStyleProvider)
     {
-        super(keyingProvider, algorithmsProvider, basicSignatureOptionsProvider, dataObjectDescsProcessor, signaturePropsProvider, dataObjPropsProvider, propsDataObjectsGenerator, signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller, x500NameStyleProvider);
+        super(keyingProvider, algorithmsProvider, basicSignatureOptions, dataObjectDescsProcessor, signaturePropsProvider, dataObjPropsProvider, propsDataObjectsGenerator, signedPropsMarshaller, unsignedPropsMarshaller, algorithmsParametersMarshaller, x500NameStyleProvider);
     }
 
     @Inject(optional = true)

--- a/src/main/java/xades4j/production/XadesSigningProfile.java
+++ b/src/main/java/xades4j/production/XadesSigningProfile.java
@@ -222,17 +222,42 @@ public abstract class XadesSigningProfile
         return withBinding(X500NameStyleProvider.class, x500NameStyleProviderClass);
     }
 
-
+    /**
+     * @deprecated
+     * <p>
+     * This method is deprecated and might be removed on future versions. Classes
+     * registered using this method will be adapted to the new {@link BasicSignatureOptions}
+     * class. If a {@BasicSignatureOptions} instance is registered it will override
+     * any registered {@link BasicSignatureOptionsProvider}.
+     * 
+     * @see #withBasicSignatureOptions(BasicSignatureOptions)
+     */
     public XadesSigningProfile withBasicSignatureOptionsProvider(
             BasicSignatureOptionsProvider optionsProvider)
     {
         return withBinding(BasicSignatureOptionsProvider.class, optionsProvider);
     }
 
+    /**
+     * @deprecated
+     * <p>
+     * This method is deprecated and might be removed on future versions. Classes
+     * registered using this method will be adapted to the new {@link BasicSignatureOptions}
+     * class. If a {@BasicSignatureOptions} instance is registered it will override
+     * any registered {@link BasicSignatureOptionsProvider}.
+     * 
+     * @see #withBasicSignatureOptions(BasicSignatureOptions)
+     */
     public XadesSigningProfile withBasicSignatureOptionsProvider(
             Class<? extends BasicSignatureOptionsProvider> optionsProvider)
     {
         return withBinding(BasicSignatureOptionsProvider.class, optionsProvider);
+    }
+    
+    public XadesSigningProfile withBasicSignatureOptions(
+            BasicSignatureOptions options)
+    {
+        return withBinding(BasicSignatureOptions.class, options);
     }
 
     public XadesSigningProfile withSignaturePropertiesProvider(

--- a/src/main/java/xades4j/providers/BasicSignatureOptionsProvider.java
+++ b/src/main/java/xades4j/providers/BasicSignatureOptionsProvider.java
@@ -17,17 +17,17 @@
 package xades4j.providers;
 
 /**
- * Provides basic signature options such as whether {@code ds:KeyInfo} elements
- * should be included.
- *
- * A default implementation is provided.
- * @see xades4j.providers.impl.DefaultBasicSignatureOptionsProvider
+ * @deprecated
+ * This interface is deprecated and might be removed in future versions.
+ * @see xades4j.production.BasicSignatureOptions
  * 
  * @author Luís
  */
 public interface BasicSignatureOptionsProvider
 {
     /**
+     * @deprecated the interface is deprecated
+     * 
      * Indicates whether the signing certificate, the subject name and issuer/serial
      * should be included within {@code ds:KeyInfo}.
      * @return {@code true} if the certificate should be included; false otherwise
@@ -35,6 +35,8 @@ public interface BasicSignatureOptionsProvider
     boolean includeSigningCertificate();
 
     /**
+     * @deprecated the interface is deprecated
+     * 
      * Indicates whether a {@code ds:KeyValue} element containing the public key's
      * value should be included in {@code ds:KeyInfo}.
      * @return {@code true} if the public key should be included; false otherwise
@@ -42,6 +44,8 @@ public interface BasicSignatureOptionsProvider
     boolean includePublicKey();
 
     /**
+     * @deprecated the interface is deprecated
+     * 
      * Indicates whether the signature should cover the {@code ds:X509Certificate}
      * element containing the signing certificate. This is only considered if
      * {@link #includeSigningCertificate()} returns {@code true}.

--- a/src/main/java/xades4j/providers/impl/DefaultBasicSignatureOptionsProvider.java
+++ b/src/main/java/xades4j/providers/impl/DefaultBasicSignatureOptionsProvider.java
@@ -19,13 +19,10 @@ package xades4j.providers.impl;
 import xades4j.providers.BasicSignatureOptionsProvider;
 
 /**
- * The default implementation of {@link BasicSignatureOptionsProvider}. The defaults
- * are:
- * <ul>
- *  <li>includeSigningCertificate: true</li>
- *  <li>includePublicKey: false</li>
- *  <li>signSigningCertificate: false</li>
- * </ul>
+ * @deprecated
+ * This class is deprecated and might be removed in future versions.
+ * @see xades4j.production.BasicSignatureOptions
+ * 
  * @author Luís
  */
 public class DefaultBasicSignatureOptionsProvider implements BasicSignatureOptionsProvider

--- a/src/test/java/xades4j/production/KeyInfoBuilderTest.java
+++ b/src/test/java/xades4j/production/KeyInfoBuilderTest.java
@@ -71,6 +71,42 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         XMLX509Certificate x509Certificate = xmlSignature.getKeyInfo().itemX509Data(0).itemCertificate(0);
         Assert.assertEquals(testCertificate, x509Certificate.getX509Certificate());
     }
+    
+    @Test
+    public void testIncludeIssuerSerial() throws Exception
+    {
+        System.out.println("includeIssuerSerial");
+
+        KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
+                new BasicSignatureOptions().includeIssuerSerial(true),
+                new TestAlgorithmsProvider(),
+                new TestAlgorithmsParametersMarshallingProvider(),
+                new DefaultX500NameStyleProvider());
+        XMLSignature xmlSignature = getTestSignature();
+
+        keyInfoBuilder.buildKeyInfo(testCertificate, xmlSignature);
+
+        Assert.assertEquals(1, xmlSignature.getKeyInfo().lengthX509Data());
+        Assert.assertEquals(1, xmlSignature.getKeyInfo().itemX509Data(0).lengthIssuerSerial());
+    }
+    
+    @Test
+    public void testIncludeSubjectName() throws Exception
+    {
+        System.out.println("includeSubjectName");
+
+        KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
+                new BasicSignatureOptions().includeSubjectName(true),
+                new TestAlgorithmsProvider(),
+                new TestAlgorithmsParametersMarshallingProvider(),
+                new DefaultX500NameStyleProvider());
+        XMLSignature xmlSignature = getTestSignature();
+
+        keyInfoBuilder.buildKeyInfo(testCertificate, xmlSignature);
+
+        Assert.assertEquals(1, xmlSignature.getKeyInfo().lengthX509Data());
+        Assert.assertEquals(1, xmlSignature.getKeyInfo().itemX509Data(0).lengthSubjectName());
+    }
 
     @Test
     public void testIgnoreSignSigningCertificateIfNotIncluded() throws Exception

--- a/src/test/java/xades4j/production/KeyInfoBuilderTest.java
+++ b/src/test/java/xades4j/production/KeyInfoBuilderTest.java
@@ -29,7 +29,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
-import xades4j.providers.BasicSignatureOptionsProvider;
 import xades4j.providers.impl.DefaultX500NameStyleProvider;
 import xades4j.utils.SignatureServicesTestBase;
 
@@ -39,40 +38,6 @@ import xades4j.utils.SignatureServicesTestBase;
  */
 public class KeyInfoBuilderTest extends SignatureServicesTestBase
 {
-
-    static class TestBasicSignatureOptionsProvider implements BasicSignatureOptionsProvider
-    {
-
-        private final boolean includeSigningCertificate;
-        private final boolean includePublicKey;
-        private final boolean signSigningCertificate;
-
-        public TestBasicSignatureOptionsProvider(boolean includeSigningCertificate, boolean includePublicKey, boolean signSigningCertificate)
-        {
-            this.includeSigningCertificate = includeSigningCertificate;
-            this.includePublicKey = includePublicKey;
-            this.signSigningCertificate = signSigningCertificate;
-        }
-
-        @Override
-        public boolean includeSigningCertificate()
-        {
-            return this.includeSigningCertificate;
-        }
-
-        @Override
-        public boolean includePublicKey()
-        {
-            return this.includePublicKey;
-        }
-
-        @Override
-        public boolean signSigningCertificate()
-        {
-            return this.signSigningCertificate;
-        }
-    }
-    /*****/
     private static X509Certificate testCertificate;
 
     @BeforeClass
@@ -90,7 +55,7 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         System.out.println("includeCertAndKey");
 
         KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new TestBasicSignatureOptionsProvider(true, true, false),
+                new BasicSignatureOptions().includeSigningCertificate(true).includePublicKey(true),
                 new TestAlgorithmsProvider(),
                 new TestAlgorithmsParametersMarshallingProvider(),
                 new DefaultX500NameStyleProvider());
@@ -113,7 +78,7 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         System.out.println("ignoreSignSigningCertificateIfNotIncluded");
 
         KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new TestBasicSignatureOptionsProvider(false, true, true),
+                new BasicSignatureOptions().signSigningCertificate(true).includePublicKey(true),
                 new TestAlgorithmsProvider(),
                 new TestAlgorithmsParametersMarshallingProvider(),
                 new DefaultX500NameStyleProvider());
@@ -135,7 +100,7 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
         System.out.println("signSigningCertificateIfIncluded");
 
         KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new TestBasicSignatureOptionsProvider(true, true, true),
+                new BasicSignatureOptions().includeSigningCertificate(true).includePublicKey(true).signSigningCertificate(true),
                 new TestAlgorithmsProvider(),
                 new TestAlgorithmsParametersMarshallingProvider(),
                 new DefaultX500NameStyleProvider());

--- a/src/test/java/xades4j/production/KeyInfoBuilderTest.java
+++ b/src/test/java/xades4j/production/KeyInfoBuilderTest.java
@@ -109,34 +109,12 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
     }
 
     @Test
-    public void testIgnoreSignSigningCertificateIfNotIncluded() throws Exception
+    public void testSignKeyInfo() throws Exception
     {
-        System.out.println("ignoreSignSigningCertificateIfNotIncluded");
+        System.out.println("signKeyInfo");
 
         KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new BasicSignatureOptions().signSigningCertificate(true).includePublicKey(true),
-                new TestAlgorithmsProvider(),
-                new TestAlgorithmsParametersMarshallingProvider(),
-                new DefaultX500NameStyleProvider());
-        XMLSignature xmlSignature = getTestSignature();
-
-        keyInfoBuilder.buildKeyInfo(testCertificate, xmlSignature);
-
-        Assert.assertEquals(0, xmlSignature.getSignedInfo().getLength());
-
-        KeyValue kv = xmlSignature.getKeyInfo().itemKeyValue(0);
-        Assert.assertTrue(kv.getPublicKey().getAlgorithm().startsWith("RSA"));
-
-        Assert.assertEquals(0, xmlSignature.getKeyInfo().lengthX509Data());
-    }
-
-    @Test
-    public void testSignSigningCertificateIfIncluded() throws Exception
-    {
-        System.out.println("signSigningCertificateIfIncluded");
-
-        KeyInfoBuilder keyInfoBuilder = new KeyInfoBuilder(
-                new BasicSignatureOptions().includeSigningCertificate(true).includePublicKey(true).signSigningCertificate(true),
+                new BasicSignatureOptions().signKeyInfo(true),
                 new TestAlgorithmsProvider(),
                 new TestAlgorithmsParametersMarshallingProvider(),
                 new DefaultX500NameStyleProvider());
@@ -149,8 +127,6 @@ public class KeyInfoBuilderTest extends SignatureServicesTestBase
 
         Node refNode = signedInfo.item(0).getContentsBeforeTransformation().getSubNode();
         Assert.assertSame(xmlSignature.getKeyInfo().getElement(), refNode);
-
-        Assert.assertEquals(1, xmlSignature.getKeyInfo().lengthX509Data());
     }
 
     private XMLSignature getTestSignature() throws Exception

--- a/src/test/java/xades4j/production/SignerBESTest.java
+++ b/src/test/java/xades4j/production/SignerBESTest.java
@@ -121,9 +121,9 @@ public class SignerBESTest extends SignerTestBase
         XadesSigner signer = new XadesBesSigningProfile(keyingProviderMy)
                 .withBasicSignatureOptions(new BasicSignatureOptions()
                     .includeSigningCertificate(true)
-                    .signSigningCertificate(true)
                     .includeIssuerSerial(true)
-                    .includeSubjectName(true))
+                    .includeSubjectName(true)
+                    .signKeyInfo(true))
                 .newSigner();
         
         DataObjectDesc obj1 = new DataObjectReference("document.xml")

--- a/src/test/java/xades4j/production/SignerBESTest.java
+++ b/src/test/java/xades4j/production/SignerBESTest.java
@@ -33,7 +33,6 @@ import xades4j.properties.CounterSignatureProperty;
 import xades4j.properties.SignerRoleProperty;
 import xades4j.providers.SignaturePropertiesCollector;
 import xades4j.providers.SignaturePropertiesProvider;
-import xades4j.providers.impl.DefaultBasicSignatureOptionsProvider;
 
 /**
  *
@@ -111,14 +110,7 @@ public class SignerBESTest extends SignerTestBase
 
         outputDocument(doc, "document.signed.bes.cs.xml");
     }
-    
-    public static class MyBasicSignatureOptionsProvider extends DefaultBasicSignatureOptionsProvider{
-        @Override
-        public boolean signSigningCertificate() {
-            return true;
-        }
-    }
-    
+
     @Test
     public void testSignBESDetachedWithXPathAndNamespaces() throws Exception
     {
@@ -127,7 +119,11 @@ public class SignerBESTest extends SignerTestBase
         Document doc = getNewDocument();
         
         XadesSigner signer = new XadesBesSigningProfile(keyingProviderMy)
-                .withBasicSignatureOptionsProvider(MyBasicSignatureOptionsProvider.class)
+                .withBasicSignatureOptions(new BasicSignatureOptions()
+                    .includeSigningCertificate(true)
+                    .signSigningCertificate(true)
+                    .includeIssuerSerial(true)
+                    .includeSubjectName(true))
                 .newSigner();
         
         DataObjectDesc obj1 = new DataObjectReference("document.xml")


### PR DESCRIPTION
Add `BasicSignatureOptions` and deprecate `BasicSignatureOptionsProvider`.

Inspired by the initial proposal on #162.