### PR TITLE
[feature/support_different_timeFormats_for_Signing] Custom Time Formats for <xades:SigningTime />

### DIFF
--- a/src/main/java/xades4j/production/DataGenSigningTime.java
+++ b/src/main/java/xades4j/production/DataGenSigningTime.java
@@ -31,6 +31,6 @@ class DataGenSigningTime implements PropertyDataObjectGenerator<SigningTimePrope
             SigningTimeProperty prop,
             PropertiesDataGenerationContext ctx)
     {
-        return new SigningTimeData(prop.getSigningTime());
+        return new SigningTimeData(prop);
     }
 }

--- a/src/main/java/xades4j/properties/SigningTimeProperty.java
+++ b/src/main/java/xades4j/properties/SigningTimeProperty.java
@@ -16,37 +16,53 @@
  */
 package xades4j.properties;
 
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 /**
- * The {@code SigningTime} property specifies the time at which the signer (purportedly)
- * performed the signing process.
+ * The {@code SigningTime} property specifies the time at which the signer
+ * (purportedly) performed the signing process. Extended for working with
+ * different time formats.
  * <p>
  * This is an optional signed property that qualifies the whole signature. There
  * is at most one occurence of this property in the signature.
+ *
  * @see xades4j.providers.SignaturePropertiesProvider
  * @author Luís
+ * @author Umut
  */
 public final class SigningTimeProperty extends SignedSignatureProperty
 {
     public static final String PROP_NAME = "SigningTime";
     /**/
     private final Calendar signingTime;
+    private final SimpleDateFormat simpleDateFormatter;
 
     public SigningTimeProperty()
     {
         this.signingTime = new GregorianCalendar();
+        this.simpleDateFormatter = null;
     }
 
     public SigningTimeProperty(Calendar signingTime)
     {
         this.signingTime = signingTime;
+        this.simpleDateFormatter = null;
+    }
+
+    public SigningTimeProperty(Calendar signingTime, SimpleDateFormat simpleDateFormatter) {
+        this.signingTime = signingTime;
+        this.simpleDateFormatter = simpleDateFormatter;
     }
 
     public Calendar getSigningTime()
     {
         return signingTime;
+    }
+
+    public SimpleDateFormat getDateFormat() {
+        return simpleDateFormatter;
     }
 
     @Override

--- a/src/main/java/xades4j/properties/data/SigningTimeData.java
+++ b/src/main/java/xades4j/properties/data/SigningTimeData.java
@@ -16,7 +16,9 @@
  */
 package xades4j.properties.data;
 
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import xades4j.properties.SigningTimeProperty;
 
 /**
  *
@@ -25,12 +27,18 @@ import java.util.Calendar;
 public final class SigningTimeData implements PropertyDataObject
 {
     private final Calendar signingTime;
+    private final SigningTimeProperty signingTimeProperty;
 
     public SigningTimeData(Calendar signingTime)
     {
         this.signingTime = signingTime;
+        this.signingTimeProperty = new SigningTimeProperty(signingTime);
     }
 
+    public SigningTimeData(SigningTimeProperty signingTimeProperty) {
+        this.signingTime = signingTimeProperty.getSigningTime();
+        this.signingTimeProperty = signingTimeProperty;
+    }
     /**
      * Get the value of signingTime
      *
@@ -39,5 +47,9 @@ public final class SigningTimeData implements PropertyDataObject
     public Calendar getSigningTime()
     {
         return signingTime;
+    }
+
+    public SigningTimeProperty getSigningTimeProperty() {
+        return signingTimeProperty;
     }
 }

--- a/src/main/java/xades4j/properties/data/SigningTimeDataStructureVerifier.java
+++ b/src/main/java/xades4j/properties/data/SigningTimeDataStructureVerifier.java
@@ -16,7 +16,6 @@
  */
 package xades4j.properties.data;
 
-import java.util.Calendar;
 import xades4j.properties.SigningTimeProperty;
 
 /**
@@ -28,8 +27,8 @@ class SigningTimeDataStructureVerifier implements PropertyDataObjectStructureVer
     @Override
     public void verifyStructure(PropertyDataObject propData) throws PropertyDataStructureException
     {
-        Calendar time = ((SigningTimeData)propData).getSigningTime();
-        if (null == time)
+        SigningTimeProperty signingTimeProperty = ((SigningTimeData) propData).getSigningTimeProperty();
+        if (null == signingTimeProperty)
             throw new PropertyDataStructureException("time not specified", SigningTimeProperty.PROP_NAME);
     }
 }

--- a/src/main/java/xades4j/verification/SigningTimeVerifier.java
+++ b/src/main/java/xades4j/verification/SigningTimeVerifier.java
@@ -32,7 +32,7 @@ class SigningTimeVerifier implements QualifyingPropertyVerifier<SigningTimeData>
             SigningTimeData propData,
             QualifyingPropertyVerificationContext ctx) throws SigningTimeVerificationException
     {
-        Date now = new Date(), sigTime = propData.getSigningTime().getTime();
+        Date now = new Date(), sigTime = propData.getSigningTimeProperty().getSigningTime().getTime();
         if (!sigTime.before(now))
             throw new SigningTimeVerificationException(sigTime, now);
         return new SigningTimeProperty(propData.getSigningTime());

--- a/src/main/java/xades4j/xml/bind/DateTimeXmlAdapter.java
+++ b/src/main/java/xades4j/xml/bind/DateTimeXmlAdapter.java
@@ -18,24 +18,29 @@ package xades4j.xml.bind;
 
 import java.util.Calendar;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
+import xades4j.properties.SigningTimeProperty;
 
 /**
  *
  * @author Luís
  */
-public class DateTimeXmlAdapter extends XmlAdapter<String, Calendar>
+public class DateTimeXmlAdapter extends XmlAdapter<String, SigningTimeProperty>
 {
     @Override
-    public Calendar unmarshal(String value)
+    public SigningTimeProperty unmarshal(String value)
     {
-        return (javax.xml.bind.DatatypeConverter.parseDateTime(value));
+        return new SigningTimeProperty(javax.xml.bind.DatatypeConverter.parseDateTime(value));
     }
 
     @Override
-    public String marshal(Calendar value)
+    public String marshal(SigningTimeProperty value)
     {
         if (value == null)
             return null;
-        return (javax.xml.bind.DatatypeConverter.printDateTime(value));
+        if (value.getDateFormat() != null) {
+            return value.getDateFormat().format(value.getSigningTime().getTime());
+        } else {
+            return (javax.xml.bind.DatatypeConverter.printDateTime(value.getSigningTime()));
+        }
     }
 }

--- a/src/main/java/xades4j/xml/bind/xades/XmlSignedSignaturePropertiesType.java
+++ b/src/main/java/xades4j/xml/bind/xades/XmlSignedSignaturePropertiesType.java
@@ -6,7 +6,6 @@
 //
 package xades4j.xml.bind.xades;
 
-import java.util.Calendar;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -16,6 +15,7 @@ import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import xades4j.properties.SigningTimeProperty;
 import xades4j.xml.bind.DateTimeXmlAdapter;
 
 /**
@@ -56,7 +56,7 @@ public class XmlSignedSignaturePropertiesType
     @XmlElement(name = "SigningTime", type = String.class)
     @XmlJavaTypeAdapter(DateTimeXmlAdapter.class)
     @XmlSchemaType(name = "dateTime")
-    protected Calendar signingTime;
+    protected SigningTimeProperty signingTime;
     @XmlElement(name = "SigningCertificate")
     protected XmlCertIDListType signingCertificate;
     @XmlElement(name = "SignaturePolicyIdentifier")
@@ -79,7 +79,7 @@ public class XmlSignedSignaturePropertiesType
      *     {@link String }
      *
      */
-    public Calendar getSigningTime()
+    public SigningTimeProperty getSigningTime()
     {
         return signingTime;
     }
@@ -92,7 +92,7 @@ public class XmlSignedSignaturePropertiesType
      *     {@link String }
      *
      */
-    public void setSigningTime(Calendar value)
+    public void setSigningTime(SigningTimeProperty value)
     {
         this.signingTime = value;
     }

--- a/src/main/java/xades4j/xml/marshalling/ToXmlSigningTimeConverter.java
+++ b/src/main/java/xades4j/xml/marshalling/ToXmlSigningTimeConverter.java
@@ -16,6 +16,7 @@
  */
 package xades4j.xml.marshalling;
 
+import xades4j.properties.SigningTimeProperty;
 import xades4j.properties.data.PropertyDataObject;
 import java.util.Calendar;
 import org.w3c.dom.Document;
@@ -34,9 +35,9 @@ class ToXmlSigningTimeConverter implements SignedPropertyDataToXmlConverter
             XmlSignedPropertiesType xmlProps,
             Document doc)
     {
-        Calendar time = ((SigningTimeData)propData).getSigningTime();
+        final SigningTimeProperty signingTimeProperty = ((SigningTimeData) propData).getSigningTimeProperty();
         // The conversion to date-time string is done by JAXB with the configured
         // adapter (DateTimeXmlAdapter).
-        xmlProps.getSignedSignatureProperties().setSigningTime(time);
+        xmlProps.getSignedSignatureProperties().setSigningTime(signingTimeProperty);
     }
 }

--- a/src/main/java/xades4j/xml/unmarshalling/FromXmlSigningTimeConverter.java
+++ b/src/main/java/xades4j/xml/unmarshalling/FromXmlSigningTimeConverter.java
@@ -18,6 +18,7 @@ package xades4j.xml.unmarshalling;
 
 import java.util.Calendar;
 import xades4j.xml.bind.xades.XmlSignedSignaturePropertiesType;
+import xades4j.properties.SigningTimeProperty;
 import xades4j.properties.data.SigningTimeData;
 
 /**
@@ -31,7 +32,7 @@ class FromXmlSigningTimeConverter implements SignedSigPropFromXmlConv
             XmlSignedSignaturePropertiesType xmlProps,
             QualifyingPropertiesDataCollector propertyDataCollector) throws PropertyUnmarshalException
     {
-        Calendar sigTime = xmlProps.getSigningTime();
+        final SigningTimeProperty sigTime = xmlProps.getSigningTime();
         if (null == sigTime)
             return;
 


### PR DESCRIPTION
* Extended SigningTimeProperty implementation for support of different time formats
e.g. yyyy-MM-dd'T'HH:mm:ss'Z'
* Added new Parameter of SimpleDateFormat.class to SigningTimeProperty.
* Appropriate changes of the calls/usages of SigningTimeProperty