### PR TITLE
Fixed/updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.testSource>1.7</maven.compiler.testSource>
         <maven.compiler.testTarget>1.7</maven.compiler.testTarget>
-        <bouncycastle.version>1.56</bouncycastle.version>
+        <bouncycastle.version>1.68</bouncycastle.version>
     </properties>
 
     <description>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-multibindings</artifactId>
-            <version>2.0</version>
+            <version>4.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.santuario</groupId>
@@ -73,6 +73,16 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.3</version>
         </dependency>
     </dependencies>
 	


### PR DESCRIPTION
There is still one failing unit test where I have no idea how to fix it: https://github.com/luisgoncalves/xades4j/blob/master/src/test/java/xades4j/verification/XadesVerifierImplTest.java#L166

Also, could you please to a release of 1.5.2 soon? I cannot update xmlsec otherwise because our organization's policy is to disallow snapshot dependencies in releases.