### PR TITLE
Check keyUsage of the signer certificate during validation

### DIFF
--- a/src/main/java/xades4j/verification/SignatureSpecificVerificationOptions.java
+++ b/src/main/java/xades4j/verification/SignatureSpecificVerificationOptions.java
@@ -62,7 +62,7 @@ public class SignatureSpecificVerificationOptions
         return this.baseUriForRelativeReferences;
     }
 
-    public boolean checkKeyUsage()
+    protected boolean checkKeyUsage()
     {
         return checkKeyUsage;
     }

--- a/src/main/java/xades4j/verification/SignatureSpecificVerificationOptions.java
+++ b/src/main/java/xades4j/verification/SignatureSpecificVerificationOptions.java
@@ -72,7 +72,7 @@ public class SignatureSpecificVerificationOptions
      * allows use for signing. If enabled (the default) signature validation will
      * fail if the keyUsage of the certificate does not allow signing.
      *
-     * @param enabled {@code true} to enable the check, {@code false to disable}
+     * @param enabled {@code true} to enable the check, {@code false} to disable
      * @return the current instance
      */
     public SignatureSpecificVerificationOptions checkKeyUsage(boolean enabled)

--- a/src/main/java/xades4j/verification/SignatureSpecificVerificationOptions.java
+++ b/src/main/java/xades4j/verification/SignatureSpecificVerificationOptions.java
@@ -38,6 +38,7 @@ public class SignatureSpecificVerificationOptions
     static final SignatureSpecificVerificationOptions EMPTY = new SignatureSpecificVerificationOptions();
 
     private String baseUriForRelativeReferences;
+    private boolean checkKeyUsage = true;
     private InputStream dataForAnonymousReference;
     private Date defaultVerificationDate = new Date();
     private final List<ResourceResolverSpi> resolvers = new ArrayList<ResourceResolverSpi>(0);
@@ -59,6 +60,25 @@ public class SignatureSpecificVerificationOptions
     String getBaseUri()
     {
         return this.baseUriForRelativeReferences;
+    }
+
+    public boolean checkKeyUsage()
+    {
+        return checkKeyUsage;
+    }
+
+    /**
+     * Configures whether to check that the keyUsage of the signer certificate
+     * allows use for signing. If enabled (the default) signature validation will
+     * fail if the keyUsage of the certificate does not allow signing.
+     *
+     * @param enabled {@code true} to enable the check, {@code false to disable}
+     * @return the current instance
+     */
+    public SignatureSpecificVerificationOptions checkKeyUsage(boolean enabled)
+    {
+        this.checkKeyUsage = enabled;
+        return this;
     }
 
     /**

--- a/src/main/java/xades4j/verification/SigningCertificateKeyUsageException.java
+++ b/src/main/java/xades4j/verification/SigningCertificateKeyUsageException.java
@@ -22,7 +22,7 @@ package xades4j.verification;
  *
  * @author Fiona Klute
  */
-public class SigningCertificateKeyUsageException extends SigningCertificateVerificationException
+public final class SigningCertificateKeyUsageException extends SigningCertificateVerificationException
 {
 
     @Override

--- a/src/main/java/xades4j/verification/SigningCertificateKeyUsageException.java
+++ b/src/main/java/xades4j/verification/SigningCertificateKeyUsageException.java
@@ -1,0 +1,34 @@
+/*
+ * XAdES4j - A Java library for generation and verification of XAdES signatures.
+ * Copyright (C) 2021 achelos GmbH
+ *
+ * XAdES4j is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or any later version.
+ *
+ * XAdES4j is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with XAdES4j. If not, see <http://www.gnu.org/licenses/>.
+ */
+package xades4j.verification;
+
+/**
+ * Exception to throw in case a signing certificate has a keyUsage extension
+ * that does not allow signing.
+ *
+ * @author Fiona Klute
+ */
+public class SigningCertificateKeyUsageException extends SigningCertificateVerificationException
+{
+
+    @Override
+    protected String getVerificationMessage()
+    {
+        return "The keyUsage of the signer certificate provided in the SigningCertificate property does not allow signing.";
+    }
+
+}

--- a/src/main/java/xades4j/verification/XadesVerifierImpl.java
+++ b/src/main/java/xades4j/verification/XadesVerifierImpl.java
@@ -196,6 +196,18 @@ class XadesVerifierImpl implements XadesVerifier
         }
         X509Certificate validationCert = certValidationRes.getCerts().get(0);
 
+        if (verificationOptions.checkKeyUsage())
+        {
+            // Check key usage.
+            // - KeyUsage[0] = digitalSignature
+            // - KeyUsage[1] = nonRepudiation
+            boolean[] keyUsage = validationCert.getKeyUsage();
+            if (keyUsage != null && !keyUsage[0] && !keyUsage[1])
+            {
+                throw new SigningCertificateKeyUsageException();
+            }
+        }
+
         /* Signature verification */
 
         // Core XML-DSIG verification.

--- a/src/test/java/xades4j/production/UncheckedSignerBESTest.java
+++ b/src/test/java/xades4j/production/UncheckedSignerBESTest.java
@@ -30,8 +30,6 @@ import xades4j.verification.XAdESVerificationResult;
 import xades4j.verification.XadesVerificationProfile;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -135,20 +133,11 @@ public class UncheckedSignerBESTest extends SignerTestBase
         trySignAndVerify(keyingProviderGood, validationProvider, "document.unchecked.signed.bes.good.xml");
     }
 
-    @Test
+    @Test(expected = SigningCertificateKeyUsageException.class)
     public void testUncheckedSignBesNoSignKeyUsage() throws Exception
     {
         System.out.println("uncheckedSignBesNoSignKeyUsage");
-
-        try
-        {
-            trySignAndVerify(keyingProviderNoSign, validationProvider, "document.unchecked.signed.bes.nosign.xml");
-            fail("expected SigningCertificateKeyUsageException did not occur");
-        }
-        catch (SigningCertificateKeyUsageException e)
-        {
-            // good, this is what we expect
-        }
+        trySignAndVerify(keyingProviderNoSign, validationProvider, "document.unchecked.signed.bes.nosign.xml");
     }
 
     @Test


### PR DESCRIPTION
This adds a keyUsage check during signature validation that matches the one during signature creation. I've added a new parameter to SignatureSpecificVerificationOptions to allow opting out of the check in case anyone needs the old behavior. The existing tests pass without modification, so the certificates used there are okay.

Closes #230.
