### PR TITLE
change code according to Clean Code rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
-        <bouncycastle.version>1.76</bouncycastle.version>
+        <bouncycastle.version>1.77</bouncycastle.version>
     </properties>
 
     <description>
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.0</version>
+                <version>5.10.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -127,7 +127,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.2.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -172,7 +172,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.6.0</version>
+                        <version>3.6.3</version>
                         <configuration>
                             <docletArtifact>
                                 <groupId>com.google.doclava</groupId>

--- a/src/main/java/xades4j/production/DataGenArchiveTimeStamp.java
+++ b/src/main/java/xades4j/production/DataGenArchiveTimeStamp.java
@@ -16,7 +16,6 @@
  */
 package xades4j.production;
 
-import xades4j.algorithms.Algorithm;
 import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
@@ -26,6 +25,7 @@ import org.apache.xml.security.signature.ObjectContainer;
 import org.apache.xml.security.signature.Reference;
 import org.apache.xml.security.utils.Constants;
 import org.w3c.dom.Element;
+import xades4j.algorithms.Algorithm;
 import xades4j.properties.ArchiveTimeStampProperty;
 import xades4j.properties.CertificateValuesProperty;
 import xades4j.properties.CompleteCertificateRefsProperty;
@@ -109,7 +109,7 @@ class DataGenArchiveTimeStamp extends DataGenBaseTimeStamp<ArchiveTimeStampPrope
 
                 Integer pCnt = propsCnt.get(e.getLocalName());
                 if (pCnt != null)
-                    propsCnt.put(e.getLocalName(), pCnt += 1);
+                    propsCnt.put(e.getLocalName(), pCnt + 1);
 
             } while ((e = DOMHelper.getNextSiblingElement(e)) != null);
 

--- a/src/main/java/xades4j/production/DataGenSigAndRefsTimeStamp.java
+++ b/src/main/java/xades4j/production/DataGenSigAndRefsTimeStamp.java
@@ -16,12 +16,12 @@
  */
 package xades4j.production;
 
-import xades4j.algorithms.Algorithm;
 import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.xml.security.utils.Constants;
 import org.w3c.dom.Element;
+import xades4j.algorithms.Algorithm;
 import xades4j.properties.CompleteCertificateRefsProperty;
 import xades4j.properties.CompleteRevocationRefsProperty;
 import xades4j.properties.QualifyingProperty;
@@ -94,7 +94,7 @@ class DataGenSigAndRefsTimeStamp extends DataGenBaseTimeStamp<SigAndRefsTimeStam
                 Integer pCnt = elegiblePropsCnt.get(e.getLocalName());
                 if (pCnt != null)
                 {
-                    elegiblePropsCnt.put(e.getLocalName(), pCnt += 1);
+                    elegiblePropsCnt.put(e.getLocalName(), pCnt + 1);
                     digestInput.addNode(e);
                 }
 

--- a/src/main/java/xades4j/production/DataObjectReference.java
+++ b/src/main/java/xades4j/production/DataObjectReference.java
@@ -49,9 +49,6 @@ public final class DataObjectReference extends DataObjectDesc
         {
             throw new NullPointerException("Reference URI cannot be null");
         }
-
-        uri = uri.trim();
-
         this.uri = URI.create(uri.trim()).toString();
     }
 

--- a/src/main/java/xades4j/production/DataObjectReference.java
+++ b/src/main/java/xades4j/production/DataObjectReference.java
@@ -16,8 +16,8 @@
  */
 package xades4j.production;
 
-import xades4j.properties.DataObjectDesc;
 import java.net.URI;
+import xades4j.properties.DataObjectDesc;
 
 /**
  * A reference to a signed data object. Each instance of this class will result
@@ -51,8 +51,8 @@ public final class DataObjectReference extends DataObjectDesc
         }
 
         uri = uri.trim();
-        URI.create(uri.trim());
-        this.uri = uri;
+
+        this.uri = URI.create(uri.trim()).toString();
     }
 
     /**

--- a/src/main/java/xades4j/production/KeyInfoBuilder.java
+++ b/src/main/java/xades4j/production/KeyInfoBuilder.java
@@ -19,7 +19,6 @@ package xades4j.production;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
-
 import org.apache.xml.security.exceptions.XMLSecurityException;
 import org.apache.xml.security.keys.content.X509Data;
 import org.apache.xml.security.signature.XMLSignature;
@@ -62,28 +61,7 @@ class KeyInfoBuilder
             List<X509Certificate> signingCertificateChain,
             XMLSignature xmlSig) throws KeyingDataException, UnsupportedAlgorithmException
     {
-        X509Certificate signingCertificate = signingCertificateChain.get(0);
-
-        if (this.basicSignatureOptions.checkKeyUsage())
-        {
-            // Check key usage.
-            // - KeyUsage[0] = digitalSignature
-            // - KeyUsage[1] = nonRepudiation
-            boolean[] keyUsage = signingCertificate.getKeyUsage();
-            if (keyUsage != null && !keyUsage[0] && !keyUsage[1])
-            {
-                throw new SigningCertKeyUsageException(signingCertificate);
-            }
-        }
-
-        if (this.basicSignatureOptions.checkCertificateValidity()) {
-            try {
-                signingCertificate.checkValidity();
-            } catch (final CertificateException ce) {
-                // CertificateExpiredException or CertificateNotYetValidException
-                throw new SigningCertValidityException(signingCertificate);
-            }
-        }
+        X509Certificate signingCertificate = getSigningCertificate(signingCertificateChain);
 
         if (this.basicSignatureOptions.includeSigningCertificate() != SigningCertificateMode.NONE
             || this.basicSignatureOptions.includeIssuerSerial()
@@ -151,5 +129,31 @@ class KeyInfoBuilder
                     this.signatureAlgorithms.getDigestAlgorithmForDataObjectReferences(), ex);
             }
         }
+    }
+
+    private X509Certificate getSigningCertificate(List<X509Certificate> signingCertificateChain) throws SigningCertKeyUsageException, SigningCertValidityException {
+        X509Certificate signingCertificate = signingCertificateChain.get(0);
+
+        if (this.basicSignatureOptions.checkKeyUsage())
+        {
+            // Check key usage.
+            // - KeyUsage[0] = digitalSignature
+            // - KeyUsage[1] = nonRepudiation
+            boolean[] keyUsage = signingCertificate.getKeyUsage();
+            if (keyUsage != null && !keyUsage[0] && !keyUsage[1])
+            {
+                throw new SigningCertKeyUsageException(signingCertificate);
+            }
+        }
+
+        if (this.basicSignatureOptions.checkCertificateValidity()) {
+            try {
+                signingCertificate.checkValidity();
+            } catch (final CertificateException ce) {
+                // CertificateExpiredException or CertificateNotYetValidException
+                throw new SigningCertValidityException(signingCertificate);
+            }
+        }
+        return signingCertificate;
     }
 }

--- a/src/main/java/xades4j/production/KeyInfoBuilder.java
+++ b/src/main/java/xades4j/production/KeyInfoBuilder.java
@@ -132,6 +132,20 @@ class KeyInfoBuilder
     }
 
     private X509Certificate getSigningCertificate(List<X509Certificate> signingCertificateChain) throws SigningCertKeyUsageException, SigningCertValidityException {
+        X509Certificate signingCertificate = getX509Certificate(signingCertificateChain);
+
+        if (this.basicSignatureOptions.checkCertificateValidity()) {
+            try {
+                signingCertificate.checkValidity();
+            } catch (final CertificateException ce) {
+                // CertificateExpiredException or CertificateNotYetValidException
+                throw new SigningCertValidityException(signingCertificate);
+            }
+        }
+        return signingCertificate;
+    }
+
+    private X509Certificate getX509Certificate(List<X509Certificate> signingCertificateChain) throws SigningCertKeyUsageException {
         X509Certificate signingCertificate = signingCertificateChain.get(0);
 
         if (this.basicSignatureOptions.checkKeyUsage())
@@ -143,15 +157,6 @@ class KeyInfoBuilder
             if (keyUsage != null && !keyUsage[0] && !keyUsage[1])
             {
                 throw new SigningCertKeyUsageException(signingCertificate);
-            }
-        }
-
-        if (this.basicSignatureOptions.checkCertificateValidity()) {
-            try {
-                signingCertificate.checkValidity();
-            } catch (final CertificateException ce) {
-                // CertificateExpiredException or CertificateNotYetValidException
-                throw new SigningCertValidityException(signingCertificate);
             }
         }
         return signingCertificate;

--- a/src/main/java/xades4j/production/PropertyDataGenerationException.java
+++ b/src/main/java/xades4j/production/PropertyDataGenerationException.java
@@ -16,8 +16,8 @@
  */
 package xades4j.production;
 
-import xades4j.properties.QualifyingProperty;
 import xades4j.XAdES4jException;
+import xades4j.properties.QualifyingProperty;
 
 /**
  * Thrown when there is an error generating a property data object.
@@ -25,7 +25,7 @@ import xades4j.XAdES4jException;
  */
 public class PropertyDataGenerationException extends XAdES4jException
 {
-    private final QualifyingProperty sourceProperty;
+    private final transient QualifyingProperty sourceProperty;
 
     public PropertyDataGenerationException(QualifyingProperty sourceProperty, String message)
     {

--- a/src/main/java/xades4j/production/SignerT.java
+++ b/src/main/java/xades4j/production/SignerT.java
@@ -17,6 +17,10 @@
 package xades4j.production;
 
 import jakarta.inject.Inject;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import xades4j.properties.SignedSignatureProperty;
 import xades4j.properties.UnsignedSignatureProperty;
 import xades4j.providers.DataObjectPropertiesProvider;
@@ -30,11 +34,6 @@ import xades4j.xml.marshalling.SignedPropertiesMarshaller;
 import xades4j.xml.marshalling.UnsignedPropertiesMarshaller;
 import xades4j.xml.marshalling.algorithms.AlgorithmsParametersMarshallingProvider;
 
-import java.security.cert.X509Certificate;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
 /**
  * Produces XAdES-T signatures. Doesn't extend SignerEPES because XAdES-T may be
  * based on XAdES-BES. If T+EPES is needed, a {@code SignaturePolicyInfoProvider}
@@ -43,7 +42,7 @@ import java.util.Optional;
  */
 class SignerT extends SignerBES
 {
-    private Optional<SignaturePolicyInfoProvider> policyInfoProvider;
+    private final Optional<SignaturePolicyInfoProvider> policyInfoProvider;
 
     @Inject
     protected SignerT(

--- a/src/main/java/xades4j/production/XadesFormatExtenderProfile.java
+++ b/src/main/java/xades4j/production/XadesFormatExtenderProfile.java
@@ -18,11 +18,11 @@ package xades4j.production;
 
 import com.google.inject.Module;
 import xades4j.properties.QualifyingProperty;
-import xades4j.utils.XadesProfileCore;
-import xades4j.utils.XadesProfileResolutionException;
 import xades4j.providers.MessageDigestEngineProvider;
 import xades4j.providers.TimeStampTokenProvider;
 import xades4j.utils.UtilsBindingsModule;
+import xades4j.utils.XadesProfileCore;
+import xades4j.utils.XadesProfileResolutionException;
 import xades4j.xml.marshalling.MarshallingBindingsModule;
 import xades4j.xml.marshalling.UnsignedPropertiesMarshaller;
 import xades4j.xml.marshalling.algorithms.AlgorithmParametersBindingsModule;
@@ -63,7 +63,7 @@ public class XadesFormatExtenderProfile
     }
 
     public final XadesFormatExtenderProfile with(Object instance) {
-        this.profileCore.addBinding((Class)instance.getClass(), instance);
+        this.profileCore.addBinding((Class<Object>)instance.getClass(), instance);
         return this;
     }
 

--- a/src/main/java/xades4j/production/XadesSigner.java
+++ b/src/main/java/xades4j/production/XadesSigner.java
@@ -42,7 +42,7 @@ public interface XadesSigner
      * @see SignedDataObjects
      * @throws XAdES4jException if an error occurs
      */
-    public XadesSignatureResult sign(
+    XadesSignatureResult sign(
             SignedDataObjects signedDataObjects,
             Node parent) throws XAdES4jException;
 
@@ -52,7 +52,7 @@ public interface XadesSigner
      * or last child of a node.
      * @see SignatureAppendingStrategies
      */
-    public interface SignatureAppendingStrategy
+    interface SignatureAppendingStrategy
     {
         /**
          * Appends the signature element to the DOM tree using the given node as
@@ -82,7 +82,7 @@ public interface XadesSigner
      * @see SignatureAppendingStrategies
      * @throws XAdES4jException if an error occurs
      */
-    public XadesSignatureResult sign(
+    XadesSignatureResult sign(
             SignedDataObjects signedDataObjects,
             Node referenceNode,
             SignatureAppendingStrategy appendingStrategy) throws XAdES4jException;

--- a/src/main/java/xades4j/production/XadesSigningProfile.java
+++ b/src/main/java/xades4j/production/XadesSigningProfile.java
@@ -101,7 +101,7 @@ public abstract class XadesSigningProfile
     /**
      * Creates a new {@code XadesSigner} based on the current state of the profile.
      * If any changes are made after this call, the previously returned signer will
-     * not be afected. Other signers can be created, accumulating the profile changes.
+     * not be affected. Other signers can be created, accumulating the profile changes.
      * @return a {@code XadesSigner} accordingly to this profile
      * @throws XadesProfileResolutionException if the dependencies of the signer (direct and indirect) cannot be resolved
      */

--- a/src/main/java/xades4j/production/XadesSigningProfile.java
+++ b/src/main/java/xades4j/production/XadesSigningProfile.java
@@ -18,15 +18,15 @@ package xades4j.production;
 
 import com.google.inject.Module;
 import xades4j.properties.QualifyingProperty;
-import xades4j.providers.X500NameStyleProvider;
-import xades4j.utils.XadesProfileCore;
-import xades4j.utils.XadesProfileResolutionException;
 import xades4j.providers.DataObjectPropertiesProvider;
 import xades4j.providers.KeyingDataProvider;
 import xades4j.providers.MessageDigestEngineProvider;
 import xades4j.providers.SignaturePropertiesProvider;
 import xades4j.providers.TimeStampTokenProvider;
+import xades4j.providers.X500NameStyleProvider;
 import xades4j.utils.UtilsBindingsModule;
+import xades4j.utils.XadesProfileCore;
+import xades4j.utils.XadesProfileResolutionException;
 import xades4j.xml.marshalling.MarshallingBindingsModule;
 import xades4j.xml.marshalling.SignedPropertiesMarshaller;
 import xades4j.xml.marshalling.UnsignedPropertiesMarshaller;
@@ -161,7 +161,7 @@ public abstract class XadesSigningProfile
      * @return this profile
      */
     public final XadesSigningProfile with(Object instance) {
-        this.profileCore.addBinding((Class)instance.getClass(), instance);
+        this.profileCore.addBinding((Class<Object>)instance.getClass(), instance);
         return this;
     }
 

--- a/src/main/java/xades4j/properties/DataObjectProperty.java
+++ b/src/main/java/xades4j/properties/DataObjectProperty.java
@@ -52,12 +52,12 @@ public abstract class DataObjectProperty implements QualifyingProperty
         private final int multiplicity;
         private final int initialSize;
 
-        private TargetMultiplicity(int mult)
+        TargetMultiplicity(int mult)
         {
             this(mult, mult);
         }
 
-        private TargetMultiplicity(int mult, int size)
+        TargetMultiplicity(int mult, int size)
         {
             this.multiplicity = mult;
             this.initialSize = size;

--- a/src/main/java/xades4j/properties/IdentifierType.java
+++ b/src/main/java/xades4j/properties/IdentifierType.java
@@ -38,15 +38,15 @@ package xades4j.properties;
 public enum IdentifierType
 {
     /**
-     * The identifier is an URI.
+     * The identifier is a URI.
      */
     URI,
     /**
-     * The identifier is an Object IDentifier encoded as an URI
+     * The identifier is an Object Identifier encoded as a URI
      */
-    OIDAsURI,
+    OID_AS_URI,
     /**
-     * The identifier is an Object IDentifier encoded as an URN
+     * The identifier is an Object Identifier encoded as a URN
      */
-    OIDAsURN
+    OID_AS_URN
 }

--- a/src/main/java/xades4j/properties/IdentifierType.java
+++ b/src/main/java/xades4j/properties/IdentifierType.java
@@ -45,8 +45,12 @@ public enum IdentifierType
      * The identifier is an Object Identifier encoded as a URI
      */
     OID_AS_URI,
+    @Deprecated(since="2.2.2")
+    OIDAsURI,
     /**
      * The identifier is an Object Identifier encoded as a URN
      */
-    OID_AS_URN
+    OID_AS_URN,
+    @Deprecated(since="2.2.2")
+    OIDAsURN
 }

--- a/src/main/java/xades4j/properties/QualifyingProperty.java
+++ b/src/main/java/xades4j/properties/QualifyingProperty.java
@@ -25,67 +25,67 @@ public interface QualifyingProperty
     /**
      * The XAdES v1.3.2 namespace URI.
      */
-    public static final String XADES_XMLNS = "http://uri.etsi.org/01903/v1.3.2#";
+    String XADES_XMLNS = "http://uri.etsi.org/01903/v1.3.2#";
     /**
      * The XAdES v1.4.1 namespaceURI.
      */
-    public static final String XADESV141_XMLNS = "http://uri.etsi.org/01903/v1.4.1#";
+    String XADESV141_XMLNS = "http://uri.etsi.org/01903/v1.4.1#";
     /**
      * The name of the {@code QualifyingProperties} element.
      */
-    public static final String QUALIFYING_PROPS_TAG = "QualifyingProperties";
+    String QUALIFYING_PROPS_TAG = "QualifyingProperties";
         /**
      * The name of the {@code Target} attribute.
      */
-    public static final String TARGET_ATTR = "Target";
+        String TARGET_ATTR = "Target";
     /**
      * The name of the {@code QualifyingPropertiesReference} element.
      */
-    public static final String QUALIFYING_PROPS_REF_TAG = "QualifyingPropertiesReference";
+    String QUALIFYING_PROPS_REF_TAG = "QualifyingPropertiesReference";
     /**
      * The URI of the signed properties reference type. To be used in {@code ds:Reference}.
      */
-    public static final String SIGNED_PROPS_TYPE_URI = "http://uri.etsi.org/01903#SignedProperties";
+    String SIGNED_PROPS_TYPE_URI = "http://uri.etsi.org/01903#SignedProperties";
         /**
      * The name of the {@code SignedProperties} element.
      */
-    public static final String SIGNED_PROPS_TAG = "SignedProperties";
+        String SIGNED_PROPS_TAG = "SignedProperties";
             /**
      * The name of the {@code SignedSignatureProperties} element.
      */
-    public static final String SIGNED_SIGNATURE_PROPS_TAG = "SignedSignatureProperties";
+            String SIGNED_SIGNATURE_PROPS_TAG = "SignedSignatureProperties";
                 /**
      * The name of the {@code SignedDataObjectProperties} element.
      */
-    public static final String SIGNED_DATAOBJ_PROPS_TAG = "SignedDataObjectProperties";
+                String SIGNED_DATAOBJ_PROPS_TAG = "SignedDataObjectProperties";
         /**
      * The name of the {@code UnsignedProperties} element.
      */
-    public static final String UNSIGNED_PROPS_TAG = "UnsignedProperties";
+        String UNSIGNED_PROPS_TAG = "UnsignedProperties";
             /**
      * The name of the {@code UnsignedSignatureProperties} element.
      */
-    public static final String UNSIGNED_SIGNATURE_PROPS_TAG = "UnsignedSignatureProperties";
+            String UNSIGNED_SIGNATURE_PROPS_TAG = "UnsignedSignatureProperties";
                 /**
      * The name of the {@code UnsignedDataObjectProperties} element.
      */
-    public static final String UNSIGNED_DATAOBJ_PROPS_TAG = "UnsignedDataObjectProperties";
+                String UNSIGNED_DATAOBJ_PROPS_TAG = "UnsignedDataObjectProperties";
     /**/
     /**
      * Indicates wether the property is a signed property.
      * @return {@code true} if this is a signed property
      */
-    public boolean isSigned();
+    boolean isSigned();
 
     /**
      * Indicates wether the property is a signature property.
      * @return {@code true} if this is a signature property
      */
-    public boolean isSignature();
+    boolean isSignature();
 
     /**
      * Gets the name of the property, as specified in XAdES (the element name).
      * @return the name
      */
-    public String getName();
+    String getName();
 }

--- a/src/main/java/xades4j/properties/data/BaseCertRefsDataStructureVerifier.java
+++ b/src/main/java/xades4j/properties/data/BaseCertRefsDataStructureVerifier.java
@@ -44,7 +44,7 @@ class BaseCertRefsDataStructureVerifier implements PropertyDataObjectStructureVe
         {
             if (null == certRef)
                 throw new PropertyDataStructureException("null certificate reference", propName);
-            if (ObjectUtils.anyNull(certRef.issuerDN, certRef.serialNumber, certRef.digestAlgUri, certRef.digestValue))
+            if (ObjectUtils.anyNull(certRef.getIssuerDN(), certRef.getSerialNumber(), certRef.getDigestAlgUri(), certRef.getDigestValue()))
                 throw new PropertyDataStructureException("empty data on one or more certificate references", propName);
         }
     }

--- a/src/main/java/xades4j/properties/data/BaseXAdESTimeStampData.java
+++ b/src/main/java/xades4j/properties/data/BaseXAdESTimeStampData.java
@@ -63,7 +63,7 @@ public abstract class BaseXAdESTimeStampData implements PropertyDataObject
    /**
     * @deprecated
     */
-    @Deprecated
+    @Deprecated(since = "1.3.1")
     public String getCanonicalizationAlgorithmUri()
     {
         return this.c14n.getUri();

--- a/src/main/java/xades4j/properties/data/CRLRef.java
+++ b/src/main/java/xades4j/properties/data/CRLRef.java
@@ -25,12 +25,16 @@ import java.util.GregorianCalendar;
  */
 public class CRLRef extends CertRef
 {
-    public GregorianCalendar issueTime;
+    private final GregorianCalendar issueTime;
 
     public CRLRef(String issuerDN, BigInteger serialNumber,
             String digestAlgUri, byte[] digestValue, GregorianCalendar issueTime)
     {
         super(issuerDN, serialNumber, digestAlgUri, digestValue);
         this.issueTime = issueTime;
+    }
+
+    public GregorianCalendar getIssueTime() {
+        return issueTime;
     }
 }

--- a/src/main/java/xades4j/properties/data/CertRef.java
+++ b/src/main/java/xades4j/properties/data/CertRef.java
@@ -24,13 +24,10 @@ import java.math.BigInteger;
  */
 public class CertRef
 {
-    public String digestAlgUri;
-    /**
-     * The digest value for the certificate, already decoded from base-64.
-     */
-    public byte[] digestValue;
-    public String issuerDN;
-    public BigInteger serialNumber;
+    private final String digestAlgUri;
+    private final byte[] digestValue;
+    private final String issuerDN;
+    private final BigInteger serialNumber;
 
     public CertRef(
             String issuerDN, BigInteger serialNumber,
@@ -40,5 +37,24 @@ public class CertRef
         this.digestValue = digestValue;
         this.issuerDN = issuerDN;
         this.serialNumber = serialNumber;
+    }
+
+    public String getDigestAlgUri() {
+        return digestAlgUri;
+    }
+
+    /**
+     * The digest value for the certificate, already decoded from base-64.
+     */
+    public byte[] getDigestValue() {
+        return digestValue;
+    }
+
+    public String getIssuerDN() {
+        return issuerDN;
+    }
+
+    public BigInteger getSerialNumber() {
+        return serialNumber;
     }
 }

--- a/src/main/java/xades4j/properties/data/CompleteRevocationRefsDataStructureVerifier.java
+++ b/src/main/java/xades4j/properties/data/CompleteRevocationRefsDataStructureVerifier.java
@@ -39,10 +39,10 @@ class CompleteRevocationRefsDataStructureVerifier implements PropertyDataObjectS
             if (null == r)
                 throw new PropertyDataStructureException("null CRL reference", CompleteRevocationRefsProperty.PROP_NAME);
             if (ObjectUtils.anyNull(
-                    r.issuerDN,
-                    r.digestAlgUri,
-                    r.digestValue,
-                    r.issueTime))
+                    r.getIssuerDN(),
+                    r.getDigestAlgUri(),
+                    r.getDigestValue(),
+                    r.getIssueTime()))
                 throw new PropertyDataStructureException("empty data on one or more CRL references", CompleteRevocationRefsProperty.PROP_NAME);
         }
     }

--- a/src/main/java/xades4j/properties/data/CustomPropertiesDataObjsStructureVerifier.java
+++ b/src/main/java/xades4j/properties/data/CustomPropertiesDataObjsStructureVerifier.java
@@ -24,5 +24,5 @@ import xades4j.utils.DataGetter;
  */
 public interface CustomPropertiesDataObjsStructureVerifier
 {
-    public void verifiy(DataGetter<PropertyDataObject> dataObjsGetter) throws PropertyDataStructureException;
+    void verifiy(DataGetter<PropertyDataObject> dataObjsGetter) throws PropertyDataStructureException;
 }

--- a/src/main/java/xades4j/providers/CertificateValidationException.java
+++ b/src/main/java/xades4j/providers/CertificateValidationException.java
@@ -28,7 +28,7 @@ import xades4j.XAdES4jException;
  */
 public class CertificateValidationException extends XAdES4jException
 {
-    private final X509CertSelector certSelector;
+    private final transient X509CertSelector certSelector;
 
     public CertificateValidationException(X509CertSelector s, String message, Throwable cause)
     {

--- a/src/main/java/xades4j/providers/SignaturePolicyDocumentProvider.java
+++ b/src/main/java/xades4j/providers/SignaturePolicyDocumentProvider.java
@@ -33,6 +33,6 @@ public interface SignaturePolicyDocumentProvider
      * @param sigPolicyId the identifier of the signature policy
      * @return the policy document stream or {@code null} if not available
      */
-    public InputStream getSignaturePolicyDocumentStream(
+    InputStream getSignaturePolicyDocumentStream(
             ObjectIdentifier sigPolicyId);
 }

--- a/src/main/java/xades4j/providers/SignaturePolicyDocumentProvider.java
+++ b/src/main/java/xades4j/providers/SignaturePolicyDocumentProvider.java
@@ -29,7 +29,7 @@ import xades4j.properties.ObjectIdentifier;
 public interface SignaturePolicyDocumentProvider
 {
     /**
-     * Gets a stream to the a policy document
+     * Gets a stream to a policy document
      * @param sigPolicyId the identifier of the signature policy
      * @return the policy document stream or {@code null} if not available
      */

--- a/src/main/java/xades4j/providers/SignaturePolicyInfoProvider.java
+++ b/src/main/java/xades4j/providers/SignaturePolicyInfoProvider.java
@@ -26,5 +26,5 @@ import xades4j.properties.SignaturePolicyBase;
  */
 public interface SignaturePolicyInfoProvider
 {
-    public SignaturePolicyBase getSignaturePolicy();
+    SignaturePolicyBase getSignaturePolicy();
 }

--- a/src/main/java/xades4j/providers/SignaturePropertiesCollector.java
+++ b/src/main/java/xades4j/providers/SignaturePropertiesCollector.java
@@ -16,13 +16,13 @@
  */
 package xades4j.providers;
 
-import xades4j.properties.SigningTimeProperty;
-import xades4j.properties.SignatureProductionPlaceProperty;
 import xades4j.properties.CounterSignatureProperty;
-import xades4j.properties.OtherUnsignedSignatureProperty;
 import xades4j.properties.OtherSignedSignatureProperty;
+import xades4j.properties.OtherUnsignedSignatureProperty;
 import xades4j.properties.PropertyTargetException;
+import xades4j.properties.SignatureProductionPlaceProperty;
 import xades4j.properties.SignerRoleProperty;
+import xades4j.properties.SigningTimeProperty;
 
 /**
  * Interface for the collector of signature properties.
@@ -38,7 +38,7 @@ public interface SignaturePropertiesCollector
      * @throws NullPointerException if {@code sigTime} is {@code null}
      * @throws PropertyTargetException if {@code SigningTime} is set more than once
      */
-    public void setSigningTime(SigningTimeProperty sigTime);
+    void setSigningTime(SigningTimeProperty sigTime);
 
     /**
      * Sets the {@code SignatureProductionPlace} signed property. This can be set
@@ -47,7 +47,7 @@ public interface SignaturePropertiesCollector
      * @throws NullPointerException if {@code sigProdPlace} is {@code null}
      * @throws PropertyTargetException if {@code SignatureProductionPlace} is set more than once
      */
-    public void setSignatureProductionPlace(
+    void setSignatureProductionPlace(
             SignatureProductionPlaceProperty sigProdPlace);
 
     /**
@@ -56,7 +56,7 @@ public interface SignaturePropertiesCollector
      * @throws NullPointerException if {@code signerRole} is {@code null}
      * @throws PropertyTargetException if {@code SignerRole} is set more than once
      */
-    public void setSignerRole(SignerRoleProperty signerRole);
+    void setSignerRole(SignerRoleProperty signerRole);
 
     /**
      * Adds a {@code CounterSignature} unsigned property. Multiple counter signatures
@@ -65,7 +65,7 @@ public interface SignaturePropertiesCollector
      * @throws NullPointerException if {@code counterSig} is {@code null}
      * @throws PropertyTargetException if the property (instance) is already present
      */
-    public void addCounterSignature(CounterSignatureProperty counterSig);
+    void addCounterSignature(CounterSignatureProperty counterSig);
 
     /**
      * Adds a custom signed property. Multiple custom signed properties can be
@@ -80,7 +80,7 @@ public interface SignaturePropertiesCollector
      * @throws PropertyTargetException if the property (instance) is already present
      * @throws IllegalArgumentException if the property is not properly annotated
      */
-    public void addOtherSignatureProperty(
+    void addOtherSignatureProperty(
             OtherSignedSignatureProperty otherSignedProp);
 
     /**
@@ -96,6 +96,6 @@ public interface SignaturePropertiesCollector
      * @throws PropertyTargetException if the property (instance) is already present
      * @throws IllegalArgumentException if the property is not properly annotated
      */
-    public void addOtherSignatureProperty(
+    void addOtherSignatureProperty(
             OtherUnsignedSignatureProperty otherUnsignedProp);
 }

--- a/src/main/java/xades4j/providers/SignaturePropertiesProvider.java
+++ b/src/main/java/xades4j/providers/SignaturePropertiesProvider.java
@@ -38,5 +38,5 @@ public interface SignaturePropertiesProvider
      *
      * @see SignaturePropertiesCollector
      */
-    public void provideProperties(SignaturePropertiesCollector signedPropsCol);
+    void provideProperties(SignaturePropertiesCollector signedPropsCol);
 }

--- a/src/main/java/xades4j/providers/TimeStampTokenProvider.java
+++ b/src/main/java/xades4j/providers/TimeStampTokenProvider.java
@@ -28,7 +28,7 @@ import java.util.Date;
  */
 public interface TimeStampTokenProvider
 {
-    public static class TimeStampTokenRes
+    class TimeStampTokenRes
     {
         public final byte[] encodedTimeStampToken;
         public final Date timeStampTime;
@@ -48,7 +48,7 @@ public interface TimeStampTokenProvider
      * @return the time-stamp token data
      * @throws TimeStampTokenGenerationException if there's an error getting the time-stamp
      */
-    public TimeStampTokenRes getTimeStampToken(
+    TimeStampTokenRes getTimeStampToken(
             byte[] tsDigestInput,
             String digestAlgUri) throws TimeStampTokenGenerationException;
 }

--- a/src/main/java/xades4j/providers/TimeStampVerificationProvider.java
+++ b/src/main/java/xades4j/providers/TimeStampVerificationProvider.java
@@ -33,7 +33,7 @@ public interface TimeStampVerificationProvider
      * @return the time-stamp
      * @throws TimeStampTokenVerificationException if the token cannot be validated (see subclasses of the exception)
      */
-    public Date verifyToken(
+    Date verifyToken(
             byte[] timeStampToken,
             byte[] tsDigestInput) throws TimeStampTokenVerificationException;
 }

--- a/src/main/java/xades4j/providers/impl/DefaultTimeStampVerificationProvider.java
+++ b/src/main/java/xades4j/providers/impl/DefaultTimeStampVerificationProvider.java
@@ -17,6 +17,15 @@
 package xades4j.providers.impl;
 
 import jakarta.inject.Inject;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.Provider;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
 import org.apache.xml.security.algorithms.MessageDigestAlgorithm;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -42,16 +51,6 @@ import xades4j.providers.TimeStampTokenTSACertException;
 import xades4j.providers.TimeStampTokenVerificationException;
 import xades4j.providers.TimeStampVerificationProvider;
 import xades4j.providers.ValidationData;
-
-import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.Provider;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
 
 /**
  * Default implementation of {@code TimeStampVerificationProvider}. It verifies
@@ -122,9 +121,9 @@ public class DefaultTimeStampVerificationProvider implements TimeStampVerificati
         {
             /* Validate the TSA certificate */
             LinkedList<X509Certificate> certs = new LinkedList<>();
-            for (Object certHolder : tsToken.getCertificates().getMatches(new AllCertificatesSelector()))
+            for (X509CertificateHolder certHolder : tsToken.getCertificates().getMatches(new AllCertificatesSelector()))
             {
-                certs.add(this.x509CertificateConverter.getCertificate((X509CertificateHolder) certHolder));
+                certs.add(this.x509CertificateConverter.getCertificate(certHolder));
             }
 
             ValidationData vData = this.certificateValidationProvider.validate(
@@ -176,10 +175,10 @@ public class DefaultTimeStampVerificationProvider implements TimeStampVerificati
     }
     
     /** Selector selecting all certificates. */
-    private static class AllCertificatesSelector implements Selector {
+    private static class AllCertificatesSelector implements Selector<X509CertificateHolder> {
 
         @Override
-        public boolean match(Object o)
+        public boolean match(X509CertificateHolder x509CertHolder)
         {
             return true;
 }
@@ -188,7 +187,7 @@ public class DefaultTimeStampVerificationProvider implements TimeStampVerificati
         public Object clone()
         {
             return this;
-        }        
-        
+        }
+
     }
 }

--- a/src/main/java/xades4j/providers/impl/DefaultTimeStampVerificationProvider.java
+++ b/src/main/java/xades4j/providers/impl/DefaultTimeStampVerificationProvider.java
@@ -116,7 +116,7 @@ public class DefaultTimeStampVerificationProvider implements TimeStampVerificati
             throw new TimeStampTokenStructureException("Invalid token", ex);
         }
 
-        X509Certificate tsaCert = null;
+        X509Certificate tsaCert;
         try
         {
             /* Validate the TSA certificate */

--- a/src/main/java/xades4j/providers/impl/DefaultTimeStampVerificationProvider.java
+++ b/src/main/java/xades4j/providers/impl/DefaultTimeStampVerificationProvider.java
@@ -183,6 +183,8 @@ public class DefaultTimeStampVerificationProvider implements TimeStampVerificati
             return true;
 }
 
+        // TODO: Classes that override "clone" should be "Cloneable" and call "super.clone()"
+        // "clone" should not be overridden A copy constructor, copy factory or a custom copy function are suitable alternatives to the Object.clone
         @Override
         public Object clone()
         {

--- a/src/main/java/xades4j/providers/impl/KeyStoreKeyingDataProvider.java
+++ b/src/main/java/xades4j/providers/impl/KeyStoreKeyingDataProvider.java
@@ -86,7 +86,7 @@ public abstract class KeyStoreKeyingDataProvider implements KeyingDataProvider
      */
     public interface SigningCertificateSelector
     {
-        public class Entry
+        class Entry
         {
             private final String alias;
             private final X509Certificate certificate;

--- a/src/main/java/xades4j/providers/impl/KeyStoreKeyingDataProvider.java
+++ b/src/main/java/xades4j/providers/impl/KeyStoreKeyingDataProvider.java
@@ -186,7 +186,7 @@ public abstract class KeyStoreKeyingDataProvider implements KeyingDataProvider
             {
                 try
                 {
-                    KeyStore.CallbackHandlerProtection storeLoadProtec = null;
+                    KeyStore.CallbackHandlerProtection storeLoadProtec;
                     if (storePasswordProvider != null)
                     // Create the load protection with callback.
                     {

--- a/src/main/java/xades4j/utils/CollectionUtils.java
+++ b/src/main/java/xades4j/utils/CollectionUtils.java
@@ -119,7 +119,7 @@ public class CollectionUtils
 
     public interface Predicate<T>
     {
-        public boolean verifiedBy(T elem);
+        boolean verifiedBy(T elem);
     }
 
     public static <T> List<T> filter(Collection<T> c, Predicate<T> p)
@@ -135,7 +135,7 @@ public class CollectionUtils
 
     public interface Projector<T1, T2>
     {
-        public T2 project(T1 e);
+        T2 project(T1 e);
     }
 
     public static <TSrc, TDest> List<TDest> project(

--- a/src/main/java/xades4j/utils/DataGetter.java
+++ b/src/main/java/xades4j/utils/DataGetter.java
@@ -25,10 +25,10 @@ import xades4j.utils.CollectionUtils.Predicate;
  */
 public interface DataGetter<T>
 {
-    public Collection<T> getAll();
+    Collection<T> getAll();
 
-    public <TP extends T> Collection<TP> getOfType(
+    <TP extends T> Collection<TP> getOfType(
             Class<TP> clazz);
 
-    public Collection<T> getFiltered(Predicate<T> filter);
+    Collection<T> getFiltered(Predicate<T> filter);
 }

--- a/src/main/java/xades4j/utils/DataGetterImpl.java
+++ b/src/main/java/xades4j/utils/DataGetterImpl.java
@@ -16,14 +16,13 @@
  */
 package xades4j.utils;
 
-import xades4j.utils.CollectionUtils.Predicate;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import xades4j.utils.CollectionUtils.Predicate;
 
 /**
  *
@@ -32,7 +31,7 @@ import java.util.Set;
 public class DataGetterImpl<T> implements DataGetter<T>
 {
     private final Collection<T> all;
-    private final Map<Class, Set<T>> allByType;
+    private final Map<Class<?>, Set<T>> allByType;
 
     public DataGetterImpl(Collection<T> all)
     {
@@ -40,9 +39,9 @@ public class DataGetterImpl<T> implements DataGetter<T>
         this.allByType = getAllByType(all);
     }
 
-    private Map<Class, Set<T>> getAllByType(Collection<T> all)
+    private Map<Class<?>, Set<T>> getAllByType(Collection<T> all)
     {
-        Map<Class, Set<T>> res = new HashMap<>();
+        Map<Class<?>, Set<T>> res = new HashMap<>();
 
         for (T e : all)
         {

--- a/src/main/java/xades4j/utils/ObjectUtils.java
+++ b/src/main/java/xades4j/utils/ObjectUtils.java
@@ -22,6 +22,10 @@ package xades4j.utils;
  */
 public class ObjectUtils
 {
+    private ObjectUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
     /**
      * Indicates whether all the objects are {@code null}.
      * @param objs the set of objects to be checked

--- a/src/main/java/xades4j/utils/PropertiesSet.java
+++ b/src/main/java/xades4j/utils/PropertiesSet.java
@@ -16,8 +16,6 @@
  */
 package xades4j.utils;
 
-import xades4j.properties.PropertyTargetException;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import xades4j.properties.PropertyTargetException;
 
 /**
  * A generic bag of properties used to store properties that apply to a specific
@@ -35,7 +34,8 @@ import java.util.Set;
  */
 public class PropertiesSet<T>
 {
-    private final Map<Class, Set<T>> properties;
+    public static final String CANNOT_BE_NULL = "Property cannot be null";
+    private final Map<Class<?>, Set<T>> properties;
 
     /**
      * Initializes the property bag with the given initial diferent property types.
@@ -48,7 +48,7 @@ public class PropertiesSet<T>
 
     /**
      * Puts a property in the bag. The put operation doesn't allow repeated
-     * property types. If a property of this type was previously added an exception
+     * property types. If a property of this type was previously added, an exception
      * is thrown.
      *
      * @param prop the property
@@ -60,9 +60,9 @@ public class PropertiesSet<T>
     public void put(T prop)
     {
         if (null == prop)
-            throw new NullPointerException("Property cannot be null");
+            throw new NullPointerException(CANNOT_BE_NULL);
 
-        // If an entry for the property's type is already present it means that a
+        // If an entry for the property's type is already present, it means that a
         // property of this type was previously added. Adding another property of
         // this type is not allowed.
         if (properties.containsKey(prop.getClass()))
@@ -83,7 +83,7 @@ public class PropertiesSet<T>
     public void add(T prop)
     {
         if (null == prop)
-            throw new NullPointerException("Property cannot be null");
+            throw new NullPointerException(CANNOT_BE_NULL);
 
       Set<T> propsOfCurrType = properties.computeIfAbsent(prop.getClass(), k -> new HashSet<>(1));
 
@@ -103,7 +103,7 @@ public class PropertiesSet<T>
     public void remove(T prop)
     {
         if (null == prop)
-            throw new NullPointerException("Property cannot be null");
+            throw new NullPointerException(CANNOT_BE_NULL);
 
         Set<T> propsOfCurrType = properties.get(prop.getClass());
         if (null == propsOfCurrType || !propsOfCurrType.remove(prop))

--- a/src/main/java/xades4j/utils/StringUtils.java
+++ b/src/main/java/xades4j/utils/StringUtils.java
@@ -22,6 +22,9 @@ package xades4j.utils;
  */
 public class StringUtils
 {
+    private StringUtils() {
+        throw new IllegalStateException("Utility class");
+    }
     public static boolean isNullOrEmptyString(String s)
     {
         return null == s || s.isEmpty();

--- a/src/main/java/xades4j/utils/TransformUtils.java
+++ b/src/main/java/xades4j/utils/TransformUtils.java
@@ -34,6 +34,10 @@ import xades4j.xml.marshalling.algorithms.AlgorithmsParametersMarshallingProvide
  */
 public final class TransformUtils
 {
+
+    private TransformUtils() {
+        throw new IllegalStateException("Utility class");
+    }
     /**
      * Creates a Transform element for a given algorithm.
      * @param algorithm algorithm

--- a/src/main/java/xades4j/utils/XadesProfileCore.java
+++ b/src/main/java/xades4j/utils/XadesProfileCore.java
@@ -26,7 +26,6 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.util.Modules;
 import com.google.inject.util.Types;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -91,7 +90,7 @@ public final class XadesProfileCore
 
         this.bindings.add(b -> {
             ParameterizedType pt = Types.newParameterizedType(genericClass, genericClassParams);
-            Key k = Key.get(TypeLiteral.get(pt));
+            Key<Object> k = (Key<Object>) Key.get(TypeLiteral.get(pt));
             b.bind(k).to(to);
         });
     }
@@ -106,7 +105,7 @@ public final class XadesProfileCore
 
         this.bindings.add(b -> {
             ParameterizedType pt = Types.newParameterizedType(genericClass, genericClassParams);
-            Key k = Key.get(TypeLiteral.get(pt));
+            Key<Object> k = (Key<Object>) Key.get(TypeLiteral.get(pt));
             b.bind(k).toInstance(to);
         });
     }
@@ -144,7 +143,7 @@ public final class XadesProfileCore
             throw new NullPointerException();
 
         this.bindings.add(b -> {
-            MapBinder mapBinder = MapBinder.newMapBinder(b, key.getClass(), valueClass);
+            MapBinder<Object,Object> mapBinder = (MapBinder<Object, Object>) MapBinder.newMapBinder(b, key.getClass(), valueClass);
             mapBinder.addBinding(key).toInstance(value);
         });
     }
@@ -155,7 +154,7 @@ public final class XadesProfileCore
             throw new NullPointerException();
 
         this.bindings.add(b -> {
-            MapBinder mapBinder = MapBinder.newMapBinder(b, key.getClass(), valueClass);
+            MapBinder<Object,Object> mapBinder = (MapBinder<Object, Object>) MapBinder.newMapBinder(b, key.getClass(), valueClass);
             mapBinder.addBinding(key).to(to);
         });
     }

--- a/src/main/java/xades4j/verification/CertRefUtils.java
+++ b/src/main/java/xades4j/verification/CertRefUtils.java
@@ -16,16 +16,15 @@
  */
 package xades4j.verification;
 
-import xades4j.UnsupportedAlgorithmException;
-import xades4j.XAdES4jException;
-import xades4j.properties.data.CertRef;
-import xades4j.providers.MessageDigestEngineProvider;
-
 import java.security.MessageDigest;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
+import xades4j.UnsupportedAlgorithmException;
+import xades4j.XAdES4jException;
+import xades4j.properties.data.CertRef;
+import xades4j.providers.MessageDigestEngineProvider;
 
 /**
  *
@@ -33,6 +32,10 @@ import java.util.Collection;
  */
 class CertRefUtils
 {
+    private CertRefUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
     static CertRef findCertRef(
             X509Certificate cert,
             Collection<CertRef> certRefs,
@@ -42,8 +45,8 @@ class CertRefUtils
         {
             try
             {
-                if (dnComparer.areEqual(cert.getIssuerX500Principal(), certRef.issuerDN) &&
-                    certRef.serialNumber.equals(cert.getSerialNumber()))
+                if (dnComparer.areEqual(cert.getIssuerX500Principal(), certRef.getIssuerDN()) &&
+                    certRef.getSerialNumber().equals(cert.getSerialNumber()))
                 {
                     return certRef;
                 }
@@ -55,7 +58,7 @@ class CertRefUtils
                     @Override
                     protected String getVerificationMessage()
                     {
-                        return String.format("Invalid issue name: %s", certRef.issuerDN);
+                        return String.format("Invalid issue name: %s", certRef.getIssuerDN());
                     }
                 };
             }
@@ -80,9 +83,9 @@ class CertRefUtils
         Throwable t = null;
         try
         {
-            messageDigest = messageDigestProvider.getEngine(certRef.digestAlgUri);
+            messageDigest = messageDigestProvider.getEngine(certRef.getDigestAlgUri());
             byte[] actualDigest = messageDigest.digest(cert.getEncoded());
-            if (!Arrays.equals(certRef.digestValue, actualDigest))
+            if (!Arrays.equals(certRef.getDigestValue(), actualDigest))
                 throw new InvalidCertRefException("digests mismatch");
             return;
         } catch (UnsupportedAlgorithmException | CertificateEncodingException ex)

--- a/src/main/java/xades4j/verification/CertRefUtils.java
+++ b/src/main/java/xades4j/verification/CertRefUtils.java
@@ -80,7 +80,7 @@ class CertRefUtils
             MessageDigestEngineProvider messageDigestProvider) throws InvalidCertRefException
     {
         MessageDigest messageDigest;
-        Throwable t = null;
+        Throwable t;
         try
         {
             messageDigest = messageDigestProvider.getEngine(certRef.getDigestAlgUri());

--- a/src/main/java/xades4j/verification/CompleteCertRefsReferenceException.java
+++ b/src/main/java/xades4j/verification/CompleteCertRefsReferenceException.java
@@ -28,7 +28,7 @@ import xades4j.properties.data.CertRef;
 public class CompleteCertRefsReferenceException extends CompleteCertRefsVerificationException
 {
     private final X509Certificate certificate;
-    private final CertRef certificateRef;
+    private final transient CertRef certificateRef;
     private final String msg;
 
     public CompleteCertRefsReferenceException(

--- a/src/main/java/xades4j/verification/CompleteRevocRefsReferenceException.java
+++ b/src/main/java/xades4j/verification/CompleteRevocRefsReferenceException.java
@@ -25,7 +25,7 @@ import java.security.cert.X509CRL;
  */
 public class CompleteRevocRefsReferenceException extends CompleteRevocRefsVerificationException
 {
-    private final X509CRL crl;
+    private final transient X509CRL crl;
     private final String msg;
 
     public CompleteRevocRefsReferenceException(X509CRL crl, String msg)

--- a/src/main/java/xades4j/verification/CompleteRevocRefsVerifier.java
+++ b/src/main/java/xades4j/verification/CompleteRevocRefsVerifier.java
@@ -17,14 +17,6 @@
 package xades4j.verification;
 
 import jakarta.inject.Inject;
-import xades4j.UnsupportedAlgorithmException;
-import xades4j.properties.CompleteRevocationRefsProperty;
-import xades4j.properties.QualifyingProperty;
-import xades4j.properties.data.CRLRef;
-import xades4j.properties.data.CompleteRevocationRefsData;
-import xades4j.providers.MessageDigestEngineProvider;
-import xades4j.utils.CrlExtensionsUtils;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.MessageDigest;
@@ -32,6 +24,13 @@ import java.security.cert.CRLException;
 import java.security.cert.X509CRL;
 import java.util.ArrayList;
 import java.util.Collection;
+import xades4j.UnsupportedAlgorithmException;
+import xades4j.properties.CompleteRevocationRefsProperty;
+import xades4j.properties.QualifyingProperty;
+import xades4j.properties.data.CRLRef;
+import xades4j.properties.data.CompleteRevocationRefsData;
+import xades4j.providers.MessageDigestEngineProvider;
+import xades4j.utils.CrlExtensionsUtils;
 
 /**
  * XAdES G.2.2.13
@@ -74,23 +73,23 @@ class CompleteRevocRefsVerifier implements QualifyingPropertyVerifier<CompleteRe
 
                 // Check issuer and issue time.
 
-                if (!this.dnComparer.areEqual(crl.getIssuerX500Principal(), crlRef.issuerDN) ||
-                        !crl.getThisUpdate().equals(crlRef.issueTime.getTime()))
+                if (!this.dnComparer.areEqual(crl.getIssuerX500Principal(), crlRef.getIssuerDN()) ||
+                        !crl.getThisUpdate().equals(crlRef.getIssueTime().getTime()))
                     continue;
                 
                 try
                 {
                     // Check CRL number, if present.
-                    if (crlRef.serialNumber != null)
+                    if (crlRef.getSerialNumber() != null)
                     {
                         BigInteger crlNum = CrlExtensionsUtils.getCrlNumber(crl);
-                        if (crlNum != null && !crlRef.serialNumber.equals(crlNum))
+                        if (crlNum != null && !crlRef.getSerialNumber().equals(crlNum))
                             continue;
                     }
 
                     // Check digest value.
-                    MessageDigest md = this.digestEngineProvider.getEngine(crlRef.digestAlgUri);
-                    if (MessageDigest.isEqual(md.digest(crl.getEncoded()), crlRef.digestValue))
+                    MessageDigest md = this.digestEngineProvider.getEngine(crlRef.getDigestAlgUri());
+                    if (MessageDigest.isEqual(md.digest(crl.getEncoded()), crlRef.getDigestValue()))
                     {
                         match = crlRef;
                         break;

--- a/src/main/java/xades4j/verification/CoreVerificationException.java
+++ b/src/main/java/xades4j/verification/CoreVerificationException.java
@@ -24,7 +24,7 @@ import org.apache.xml.security.signature.XMLSignature;
  */
 public abstract class CoreVerificationException extends InvalidSignatureException
 {
-    private final XMLSignature signature;
+    private final transient XMLSignature signature;
 
     protected CoreVerificationException(XMLSignature sig)
     {

--- a/src/main/java/xades4j/verification/CounterSignatureVerifier.java
+++ b/src/main/java/xades4j/verification/CounterSignatureVerifier.java
@@ -82,6 +82,7 @@ class CounterSignatureVerifier implements QualifyingPropertyVerifier<GenericDOMD
                 {
                     // The signature references the SignatureValue element with
                     // C14N transforms only.
+                    // TODO: same return value as before
                     return new CounterSignatureProperty(res);
                 }
             }

--- a/src/main/java/xades4j/verification/CustomSignatureVerifier.java
+++ b/src/main/java/xades4j/verification/CustomSignatureVerifier.java
@@ -26,7 +26,7 @@ package xades4j.verification;
  */
 public interface CustomSignatureVerifier
 {
-    public void verify(
+    void verify(
             XAdESVerificationResult verificationData,
             QualifyingPropertyVerificationContext ctx) throws InvalidSignatureException;
 }

--- a/src/main/java/xades4j/verification/DataObjectFormatMismatchException.java
+++ b/src/main/java/xades4j/verification/DataObjectFormatMismatchException.java
@@ -29,8 +29,8 @@ public class DataObjectFormatMismatchException extends DataObjectFormatVerificat
 {
     private final String mimeType;
     private final String encoding;
-    private final ObjectContainer object;
-    private final Reference reference;
+    private final transient ObjectContainer object;
+    private final transient Reference reference;
 
     public DataObjectFormatMismatchException(
             String mimeType, String encoding,

--- a/src/main/java/xades4j/verification/GenericDOMDataVerifier.java
+++ b/src/main/java/xades4j/verification/GenericDOMDataVerifier.java
@@ -17,12 +17,12 @@
 package xades4j.verification;
 
 import jakarta.inject.Inject;
+import java.util.Map;
+import javax.xml.namespace.QName;
 import org.w3c.dom.Element;
 import xades4j.properties.QualifyingProperty;
 import xades4j.properties.data.GenericDOMData;
-
-import javax.xml.namespace.QName;
-import java.util.Map;
+import xades4j.properties.data.PropertyDataObject;
 
 /**
  *
@@ -46,7 +46,7 @@ class GenericDOMDataVerifier implements QualifyingPropertyVerifier<GenericDOMDat
         final Element propElem = propData.getPropertyElement();
         QName propElemQName = new QName(propElem.getNamespaceURI(), propElem.getLocalName());
 
-        QualifyingPropertyVerifier propVerifier = customElemVerifiers.get(propElemQName);
+        QualifyingPropertyVerifier<PropertyDataObject> propVerifier = customElemVerifiers.get(propElemQName);
         if (null == propVerifier)
             throw new InvalidPropertyException()
             {

--- a/src/main/java/xades4j/verification/KeyInfoProcessor.java
+++ b/src/main/java/xades4j/verification/KeyInfoProcessor.java
@@ -42,9 +42,9 @@ class KeyInfoProcessor
 
     static class KeyInfoRes
     {
-        X509CertSelector certSelector;
-        List<X509Certificate> keyInfoCerts;
-        XMLX509IssuerSerial issuerSerial;
+        final X509CertSelector certSelector;
+        final List<X509Certificate> keyInfoCerts;
+        final XMLX509IssuerSerial issuerSerial;
 
         KeyInfoRes(
             X509CertSelector certSelector,

--- a/src/main/java/xades4j/verification/KeyInfoProcessor.java
+++ b/src/main/java/xades4j/verification/KeyInfoProcessor.java
@@ -21,12 +21,10 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.xml.security.exceptions.XMLSecurityException;
 import org.apache.xml.security.keys.KeyInfo;
 import org.apache.xml.security.keys.content.X509Data;
 import org.apache.xml.security.keys.content.x509.XMLX509IssuerSerial;
-
 import xades4j.properties.data.CertRef;
 import xades4j.providers.CertificateValidationException;
 import xades4j.providers.X500NameStyleProvider;
@@ -149,8 +147,8 @@ class KeyInfoProcessor
         }
 
         X509CertSelector certSelector = new X509CertSelector();
-        certSelector.setIssuer(x500NameStyleProvider.fromString(signingCertRef.issuerDN));
-        certSelector.setSerialNumber(signingCertRef.serialNumber);
+        certSelector.setIssuer(x500NameStyleProvider.fromString(signingCertRef.getIssuerDN()));
+        certSelector.setSerialNumber(signingCertRef.getSerialNumber());
         
         return new KeyInfoRes(certSelector);     
     }

--- a/src/main/java/xades4j/verification/QualifyingPropertyVerificationContext.java
+++ b/src/main/java/xades4j/verification/QualifyingPropertyVerificationContext.java
@@ -16,6 +16,15 @@
  */
 package xades4j.verification;
 
+import java.math.BigInteger;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.security.auth.x500.X500Principal;
 import org.apache.xml.security.keys.content.x509.XMLX509IssuerSerial;
 import org.apache.xml.security.signature.ObjectContainer;
 import org.apache.xml.security.signature.XMLSignature;
@@ -28,16 +37,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import xades4j.providers.X500NameStyleProvider;
-
-import javax.security.auth.x500.X500Principal;
-import java.math.BigInteger;
-import java.security.cert.X509CRL;
-import java.security.cert.X509Certificate;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * The context available during the verification of the qualifying properties.
@@ -200,7 +199,7 @@ public class QualifyingPropertyVerificationContext
             {
                 ResourceResolverContext resolverContext = new ResourceResolverContext(refAttr, "", true);
                 XMLSignatureInput refData = ResourceResolver.resolve(resolverContext);
-                // This has to be a NodeSet data because it is a same-document reference.
+                // This has to be NodeSet data because it is a same-document reference.
                 Node refNode = refData.getSubNode();
                 if (refNode.getNodeType() != Node.ELEMENT_NODE)
                     return null;

--- a/src/main/java/xades4j/verification/QualifyingPropertyVerifier.java
+++ b/src/main/java/xades4j/verification/QualifyingPropertyVerifier.java
@@ -40,7 +40,7 @@ public interface QualifyingPropertyVerifier<TData extends PropertyDataObject>
      * @return the verified QualifyingProperty (never {@code null})
      * @throws InvalidPropertyException (or subclasses) if the property validation fails
      */
-    public QualifyingProperty verify(
+    QualifyingProperty verify(
             TData propData,
             QualifyingPropertyVerificationContext ctx) throws InvalidPropertyException;
 }

--- a/src/main/java/xades4j/verification/RawSignatureVerifier.java
+++ b/src/main/java/xades4j/verification/RawSignatureVerifier.java
@@ -36,7 +36,7 @@ public interface RawSignatureVerifier
     /**
      * The context for {@code RawSignatureVerifier}s.
      */
-    public static class RawSignatureVerifierContext
+    class RawSignatureVerifierContext
     {
         private final XMLSignature signature;
 

--- a/src/main/java/xades4j/verification/ReferenceValueException.java
+++ b/src/main/java/xades4j/verification/ReferenceValueException.java
@@ -26,7 +26,7 @@ import org.apache.xml.security.signature.XMLSignature;
  */
 public class ReferenceValueException extends CoreVerificationException
 {
-    private final Reference reference;
+    private final transient Reference reference;
 
     public ReferenceValueException(XMLSignature sig, Reference reference)
     {

--- a/src/main/java/xades4j/verification/SignaturePolicyVerificationException.java
+++ b/src/main/java/xades4j/verification/SignaturePolicyVerificationException.java
@@ -26,7 +26,7 @@ import xades4j.properties.SignaturePolicyBase;
  */
 public abstract class SignaturePolicyVerificationException extends InvalidPropertyException
 {
-    private final ObjectIdentifier signaturePolicyId;
+    private final transient ObjectIdentifier signaturePolicyId;
 
     protected SignaturePolicyVerificationException(
             ObjectIdentifier signaturePolicyId)

--- a/src/main/java/xades4j/verification/SignatureUtils.java
+++ b/src/main/java/xades4j/verification/SignatureUtils.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.xml.security.exceptions.XMLSecurityException;
 import org.apache.xml.security.signature.Reference;
 import org.apache.xml.security.signature.SignedInfo;
@@ -29,7 +28,6 @@ import org.apache.xml.security.signature.XMLSignatureException;
 import org.apache.xml.security.transforms.Transforms;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-
 import xades4j.XAdES4jXMLSigException;
 import xades4j.algorithms.GenericAlgorithm;
 import xades4j.properties.QualifyingProperty;
@@ -230,14 +228,7 @@ class SignatureUtils
 
         try
         {
-            Node sPropsNode = signedPropsRef.getNodesetBeforeFirstCanonicalization().getSubNode();
-            if (sPropsNode == null || sPropsNode.getNodeType() != Node.ELEMENT_NODE)
-            {
-                throw new QualifyingPropertiesIncorporationException("The supposed reference over signed properties doesn't cover an element.");
-            }
-
-            // The referenced signed properties element must be the child of qualifying properties.
-            Element referencedSignedPropsElem = (Element) sPropsNode;
+            Element referencedSignedPropsElem = getReferencedSignedPropsElem(signedPropsRef);
             if (referencedSignedPropsElem != signedPropsElem)
             {
                 throw new QualifyingPropertiesIncorporationException("The referenced SignedProperties are not contained by the proper QualifyingProperties element");
@@ -246,5 +237,16 @@ class SignatureUtils
         {
             throw new QualifyingPropertiesIncorporationException("Cannot get the referenced SignedProperties", ex);
         }
+    }
+
+    private static Element getReferencedSignedPropsElem(Reference signedPropsRef) throws XMLSignatureException, QualifyingPropertiesIncorporationException {
+        Node sPropsNode = signedPropsRef.getNodesetBeforeFirstCanonicalization().getSubNode();
+        if (sPropsNode == null || sPropsNode.getNodeType() != Node.ELEMENT_NODE)
+        {
+            throw new QualifyingPropertiesIncorporationException("The supposed reference over signed properties doesn't cover an element.");
+        }
+
+        // The referenced signed properties element must be the child of qualifying properties.
+        return (Element) sPropsNode;
     }
 }

--- a/src/main/java/xades4j/verification/SignatureUtils.java
+++ b/src/main/java/xades4j/verification/SignatureUtils.java
@@ -51,8 +51,8 @@ class SignatureUtils
         /**
          * In signature order.
          */
-        List<RawDataObjectDesc> dataObjsReferences;
-        Reference signedPropsReference;
+        final List<RawDataObjectDesc> dataObjsReferences;
+        final Reference signedPropsReference;
 
         ReferencesRes(
                 List<RawDataObjectDesc> dataObjsReferences,

--- a/src/main/java/xades4j/verification/SigningCertificateVerifier.java
+++ b/src/main/java/xades4j/verification/SigningCertificateVerifier.java
@@ -24,8 +24,8 @@ import javax.security.auth.x500.X500Principal;
 import xades4j.properties.QualifyingProperty;
 import xades4j.properties.SigningCertificateProperty;
 import xades4j.properties.data.CertRef;
-import xades4j.providers.MessageDigestEngineProvider;
 import xades4j.properties.data.SigningCertificateData;
+import xades4j.providers.MessageDigestEngineProvider;
 import xades4j.verification.QualifyingPropertyVerificationContext.CertificationChainData;
 
 /**
@@ -70,11 +70,11 @@ class SigningCertificateVerifier implements QualifyingPropertyVerifier<SigningCe
         // from SigningCertificate, are the same."
         X500Principal keyInfoIssuer = certChainData.getValidationCertIssuer();
         if (keyInfoIssuer != null &&
-                (!this.dnComparer.areEqual(keyInfoIssuer, signingCertRef.issuerDN) ||
-                !signingCertRef.serialNumber.equals(certChainData.getValidationCertSerialNumber())))
+                (!this.dnComparer.areEqual(keyInfoIssuer, signingCertRef.getIssuerDN()) ||
+                !signingCertRef.getSerialNumber().equals(certChainData.getValidationCertSerialNumber())))
             throw new SigningCertificateIssuerSerialMismatchException(
-                    signingCertRef.issuerDN,
-                    signingCertRef.serialNumber,
+                    signingCertRef.getIssuerDN(),
+                    signingCertRef.getSerialNumber(),
                     keyInfoIssuer.getName(),
                     certChainData.getValidationCertSerialNumber());
 

--- a/src/main/java/xades4j/verification/XAdESForm.java
+++ b/src/main/java/xades4j/verification/XAdESForm.java
@@ -34,7 +34,7 @@ public enum XAdESForm
     private final String alias;
     private final String fullName;
 
-    private XAdESForm(String alias, String fullName)
+    XAdESForm(String alias, String fullName)
     {
         this.alias = alias;
         this.fullName = fullName;

--- a/src/main/java/xades4j/verification/XadesVerificationProfile.java
+++ b/src/main/java/xades4j/verification/XadesVerificationProfile.java
@@ -18,17 +18,16 @@ package xades4j.verification;
 
 import com.google.inject.Module;
 import javax.xml.namespace.QName;
-
-import xades4j.providers.X500NameStyleProvider;
-import xades4j.utils.XadesProfileCore;
-import xades4j.utils.XadesProfileResolutionException;
 import xades4j.properties.data.CustomPropertiesDataObjsStructureVerifier;
 import xades4j.properties.data.PropertyDataObject;
 import xades4j.providers.CertificateValidationProvider;
 import xades4j.providers.MessageDigestEngineProvider;
 import xades4j.providers.SignaturePolicyDocumentProvider;
 import xades4j.providers.TimeStampVerificationProvider;
+import xades4j.providers.X500NameStyleProvider;
 import xades4j.utils.UtilsBindingsModule;
+import xades4j.utils.XadesProfileCore;
+import xades4j.utils.XadesProfileResolutionException;
 import xades4j.xml.marshalling.algorithms.AlgorithmParametersBindingsModule;
 import xades4j.xml.unmarshalling.QualifyingPropertiesUnmarshaller;
 import xades4j.xml.unmarshalling.UnmarshallingBindingsModule;
@@ -321,7 +320,7 @@ public final class XadesVerificationProfile
     }
 
     public XadesVerificationProfile withElementVerifier(
-            QName elemName, Class<? extends QualifyingPropertyVerifier<?>> vClass)
+            QName elemName, Class<? extends QualifyingPropertyVerifier<PropertyDataObject>> vClass)
     {
         if (null == elemName || null == vClass)
             throw new NullPointerException();

--- a/src/main/java/xades4j/verification/XadesVerifier.java
+++ b/src/main/java/xades4j/verification/XadesVerifier.java
@@ -57,7 +57,7 @@ public interface XadesVerifier
      * @throws XAdES4jException if an error occurs, including if signature verification fails
      * @throws NullPointerException if {@code signatureElem} is {@code null}
      */
-    public XAdESVerificationResult verify(
+    XAdESVerificationResult verify(
             Element signatureElem,
             SignatureSpecificVerificationOptions verificationOptions) throws XAdES4jException;
 
@@ -106,7 +106,7 @@ public interface XadesVerifier
      * @throws XAdES4jException if an error occurs, including if signature verification fails
      * @throws NullPointerException if any parameter is {@code null}
      */
-    public XAdESVerificationResult verify(
+    XAdESVerificationResult verify(
             Element signatureElem,
             SignatureSpecificVerificationOptions verificationOptions,
             XadesSignatureFormatExtender formatExtender,

--- a/src/main/java/xades4j/verification/XadesVerifierImpl.java
+++ b/src/main/java/xades4j/verification/XadesVerifierImpl.java
@@ -366,7 +366,7 @@ class XadesVerifierImpl implements XadesVerifier
     }
 
     /*************************************************************************************/
-    private static interface FormExtensionPropsCollector
+    private interface FormExtensionPropsCollector
     {
 
         void addProps(Collection<UnsignedSignatureProperty> usp,

--- a/src/main/java/xades4j/xml/bind/xades/ObjectFactory.java
+++ b/src/main/java/xades4j/xml/bind/xades/ObjectFactory.java
@@ -11,7 +11,6 @@ package xades4j.xml.bind.xades;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlElementDecl;
 import jakarta.xml.bind.annotation.XmlRegistry;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
@@ -33,51 +32,53 @@ import javax.xml.namespace.QName;
 @XmlRegistry
 public class ObjectFactory {
 
-    private static final QName _UnsignedDataObjectProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "UnsignedDataObjectProperties");
-    private static final QName _SignatureTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignatureTimeStamp");
-    private static final QName _IndividualDataObjectsTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "IndividualDataObjectsTimeStamp");
-    private static final QName _AttrAuthoritiesCertValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttrAuthoritiesCertValues");
-    private static final QName _ArchiveTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "ArchiveTimeStamp");
-    private static final QName _SPUserNotice_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SPUserNotice");
-    private static final QName _UnsignedProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "UnsignedProperties");
-    private static final QName _CompleteRevocationRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CompleteRevocationRefs");
-    private static final QName _AttributeRevocationValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttributeRevocationValues");
-    private static final QName _SignedSignatureProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignedSignatureProperties");
-    private static final QName _ObjectIdentifier_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "ObjectIdentifier");
-    private static final QName _OtherTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "OtherTimeStamp");
-    private static final QName _RefsOnlyTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "RefsOnlyTimeStamp");
-    private static final QName _SPURI_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SPURI");
-    private static final QName _SignedDataObjectProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignedDataObjectProperties");
-    private static final QName _CounterSignature_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CounterSignature");
-    private static final QName _QualifyingProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "QualifyingProperties");
-    private static final QName _SigningCertificate_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SigningCertificate");
-    private static final QName _ReferenceInfo_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "ReferenceInfo");
-    private static final QName _XAdESTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "XAdESTimeStamp");
-    private static final QName _SignatureProductionPlace_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignatureProductionPlace");
-    private static final QName _EncapsulatedPKIData_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "EncapsulatedPKIData");
-    private static final QName _UnsignedSignatureProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "UnsignedSignatureProperties");
-    private static final QName _CommitmentTypeIndication_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CommitmentTypeIndication");
-    private static final QName _AllDataObjectsTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AllDataObjectsTimeStamp");
-    private static final QName _SignerRole_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignerRole");
-    private static final QName _RevocationValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "RevocationValues");
-    private static final QName _ArchiveTimeStampV2_QNAME = new QName("http://uri.etsi.org/01903/v1.4.1#", "ArchiveTimeStampV2");
-    private static final QName _QualifyingPropertiesReference_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "QualifyingPropertiesReference");
-    private static final QName _CertificateValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CertificateValues");
-    private static final QName _Any_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "Any");
-    private static final QName _SignaturePolicyIdentifier_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignaturePolicyIdentifier");
-    private static final QName _SigningTime_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SigningTime");
-    private static final QName _Include_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "Include");
-    private static final QName _SigAndRefsTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SigAndRefsTimeStamp");
-    private static final QName _DataObjectFormat_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "DataObjectFormat");
-    private static final QName _AttributeCertificateRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttributeCertificateRefs");
-    private static final QName _TimeStampValidationData_QNAME = new QName("http://uri.etsi.org/01903/v1.4.1#", "TimeStampValidationData");
-    private static final QName _SignedProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignedProperties");
-    private static final QName _CompleteCertificateRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CompleteCertificateRefs");
-    private static final QName _AttributeRevocationRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttributeRevocationRefs");
+    public static final String ORG_01903_V_1_3_2 = "http://uri.etsi.org/01903/v1.3.2#";
+    public static final String ORG_01903_V_1_4_1 = "http://uri.etsi.org/01903/v1.4.1#";
+    private static final QName _UnsignedDataObjectProperties_QNAME = new QName(ORG_01903_V_1_3_2, "UnsignedDataObjectProperties");
+    private static final QName _SignatureTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "SignatureTimeStamp");
+    private static final QName _IndividualDataObjectsTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "IndividualDataObjectsTimeStamp");
+    private static final QName _AttrAuthoritiesCertValues_QNAME = new QName(ORG_01903_V_1_3_2, "AttrAuthoritiesCertValues");
+    private static final QName _ArchiveTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "ArchiveTimeStamp");
+    private static final QName _SPUserNotice_QNAME = new QName(ORG_01903_V_1_3_2, "SPUserNotice");
+    private static final QName _UnsignedProperties_QNAME = new QName(ORG_01903_V_1_3_2, "UnsignedProperties");
+    private static final QName _CompleteRevocationRefs_QNAME = new QName(ORG_01903_V_1_3_2, "CompleteRevocationRefs");
+    private static final QName _AttributeRevocationValues_QNAME = new QName(ORG_01903_V_1_3_2, "AttributeRevocationValues");
+    private static final QName _SignedSignatureProperties_QNAME = new QName(ORG_01903_V_1_3_2, "SignedSignatureProperties");
+    private static final QName _ObjectIdentifier_QNAME = new QName(ORG_01903_V_1_3_2, "ObjectIdentifier");
+    private static final QName _OtherTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "OtherTimeStamp");
+    private static final QName _RefsOnlyTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "RefsOnlyTimeStamp");
+    private static final QName _SPURI_QNAME = new QName(ORG_01903_V_1_3_2, "SPURI");
+    private static final QName _SignedDataObjectProperties_QNAME = new QName(ORG_01903_V_1_3_2, "SignedDataObjectProperties");
+    private static final QName _CounterSignature_QNAME = new QName(ORG_01903_V_1_3_2, "CounterSignature");
+    private static final QName _QualifyingProperties_QNAME = new QName(ORG_01903_V_1_3_2, "QualifyingProperties");
+    private static final QName _SigningCertificate_QNAME = new QName(ORG_01903_V_1_3_2, "SigningCertificate");
+    private static final QName _ReferenceInfo_QNAME = new QName(ORG_01903_V_1_3_2, "ReferenceInfo");
+    private static final QName _XAdESTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "XAdESTimeStamp");
+    private static final QName _SignatureProductionPlace_QNAME = new QName(ORG_01903_V_1_3_2, "SignatureProductionPlace");
+    private static final QName _EncapsulatedPKIData_QNAME = new QName(ORG_01903_V_1_3_2, "EncapsulatedPKIData");
+    private static final QName _UnsignedSignatureProperties_QNAME = new QName(ORG_01903_V_1_3_2, "UnsignedSignatureProperties");
+    private static final QName _CommitmentTypeIndication_QNAME = new QName(ORG_01903_V_1_3_2, "CommitmentTypeIndication");
+    private static final QName _AllDataObjectsTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "AllDataObjectsTimeStamp");
+    private static final QName _SignerRole_QNAME = new QName(ORG_01903_V_1_3_2, "SignerRole");
+    private static final QName _RevocationValues_QNAME = new QName(ORG_01903_V_1_3_2, "RevocationValues");
+    private static final QName _ArchiveTimeStampV2_QNAME = new QName(ORG_01903_V_1_4_1, "ArchiveTimeStampV2");
+    private static final QName _QualifyingPropertiesReference_QNAME = new QName(ORG_01903_V_1_3_2, "QualifyingPropertiesReference");
+    private static final QName _CertificateValues_QNAME = new QName(ORG_01903_V_1_3_2, "CertificateValues");
+    private static final QName _Any_QNAME = new QName(ORG_01903_V_1_3_2, "Any");
+    private static final QName _SignaturePolicyIdentifier_QNAME = new QName(ORG_01903_V_1_3_2, "SignaturePolicyIdentifier");
+    private static final QName _SigningTime_QNAME = new QName(ORG_01903_V_1_3_2, "SigningTime");
+    private static final QName _Include_QNAME = new QName(ORG_01903_V_1_3_2, "Include");
+    private static final QName _SigAndRefsTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "SigAndRefsTimeStamp");
+    private static final QName _DataObjectFormat_QNAME = new QName(ORG_01903_V_1_3_2, "DataObjectFormat");
+    private static final QName _AttributeCertificateRefs_QNAME = new QName(ORG_01903_V_1_3_2, "AttributeCertificateRefs");
+    private static final QName _TimeStampValidationData_QNAME = new QName("ORG_01903_V_1_4_1", "TimeStampValidationData");
+    private static final QName _SignedProperties_QNAME = new QName(ORG_01903_V_1_3_2, "SignedProperties");
+    private static final QName _CompleteCertificateRefs_QNAME = new QName(ORG_01903_V_1_3_2, "CompleteCertificateRefs");
+    private static final QName _AttributeRevocationRefs_QNAME = new QName(ORG_01903_V_1_3_2, "AttributeRevocationRefs");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: xades4j.marshalling.xades
-     * 
+     *
      */
     public ObjectFactory() {
         // TODO document why this constructor is empty
@@ -85,7 +86,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertifiedRolesListType }
-     * 
+     *
      */
     public XmlCertifiedRolesListType createXmlCertifiedRolesListType() {
         return new XmlCertifiedRolesListType();
@@ -93,7 +94,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCommitmentTypeIndicationType }
-     * 
+     *
      */
     public XmlCommitmentTypeIndicationType createXmlCommitmentTypeIndicationType() {
         return new XmlCommitmentTypeIndicationType();
@@ -101,7 +102,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlRevocationValuesType }
-     * 
+     *
      */
     public XmlRevocationValuesType createXmlRevocationValuesType() {
         return new XmlRevocationValuesType();
@@ -109,7 +110,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlDocumentationReferencesType }
-     * 
+     *
      */
     public XmlDocumentationReferencesType createXmlDocumentationReferencesType() {
         return new XmlDocumentationReferencesType();
@@ -117,7 +118,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSPUserNoticeType }
-     * 
+     *
      */
     public XmlSPUserNoticeType createXmlSPUserNoticeType() {
         return new XmlSPUserNoticeType();
@@ -125,7 +126,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertIDListType }
-     * 
+     *
      */
     public XmlCertIDListType createXmlCertIDListType() {
         return new XmlCertIDListType();
@@ -133,7 +134,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignedPropertiesType }
-     * 
+     *
      */
     public XmlSignedPropertiesType createXmlSignedPropertiesType() {
         return new XmlSignedPropertiesType();
@@ -141,7 +142,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignaturePolicyIdType }
-     * 
+     *
      */
     public XmlSignaturePolicyIdType createXmlSignaturePolicyIdType() {
         return new XmlSignaturePolicyIdType();
@@ -149,7 +150,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlReferenceInfoType }
-     * 
+     *
      */
     public XmlReferenceInfoType createXmlReferenceInfoType() {
         return new XmlReferenceInfoType();
@@ -157,7 +158,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPRefsType }
-     * 
+     *
      */
     public XmlOCSPRefsType createXmlOCSPRefsType() {
         return new XmlOCSPRefsType();
@@ -165,7 +166,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlEncapsulatedPKIDataType }
-     * 
+     *
      */
     public XmlEncapsulatedPKIDataType createXmlEncapsulatedPKIDataType() {
         return new XmlEncapsulatedPKIDataType();
@@ -173,7 +174,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCompleteCertificateRefsType }
-     * 
+     *
      */
     public XmlCompleteCertificateRefsType createXmlCompleteCertificateRefsType() {
         return new XmlCompleteCertificateRefsType();
@@ -181,7 +182,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlDigestAlgAndValueType }
-     * 
+     *
      */
     public XmlDigestAlgAndValueType createXmlDigestAlgAndValueType() {
         return new XmlDigestAlgAndValueType();
@@ -189,7 +190,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlObjectIdentifierType }
-     * 
+     *
      */
     public XmlObjectIdentifierType createXmlObjectIdentifierType() {
         return new XmlObjectIdentifierType();
@@ -197,7 +198,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPRefType }
-     * 
+     *
      */
     public XmlOCSPRefType createXmlOCSPRefType() {
         return new XmlOCSPRefType();
@@ -205,7 +206,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLRefType }
-     * 
+     *
      */
     public XmlCRLRefType createXmlCRLRefType() {
         return new XmlCRLRefType();
@@ -213,7 +214,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlUnsignedSignaturePropertiesType }
-     * 
+     *
      */
     public XmlUnsignedSignaturePropertiesType createXmlUnsignedSignaturePropertiesType() {
         return new XmlUnsignedSignaturePropertiesType();
@@ -221,7 +222,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignerRoleType }
-     * 
+     *
      */
     public XmlSignerRoleType createXmlSignerRoleType() {
         return new XmlSignerRoleType();
@@ -229,7 +230,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlUnsignedDataObjectPropertiesType }
-     * 
+     *
      */
     public XmlUnsignedDataObjectPropertiesType createXmlUnsignedDataObjectPropertiesType() {
         return new XmlUnsignedDataObjectPropertiesType();
@@ -237,7 +238,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlIdentifierType }
-     * 
+     *
      */
     public XmlIdentifierType createXmlIdentifierType() {
         return new XmlIdentifierType();
@@ -245,7 +246,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCounterSignatureType }
-     * 
+     *
      */
     public XmlCounterSignatureType createXmlCounterSignatureType() {
         return new XmlCounterSignatureType();
@@ -253,7 +254,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignedDataObjectPropertiesType }
-     * 
+     *
      */
     public XmlSignedDataObjectPropertiesType createXmlSignedDataObjectPropertiesType() {
         return new XmlSignedDataObjectPropertiesType();
@@ -261,7 +262,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlUnsignedPropertiesType }
-     * 
+     *
      */
     public XmlUnsignedPropertiesType createXmlUnsignedPropertiesType() {
         return new XmlUnsignedPropertiesType();
@@ -269,7 +270,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlNoticeReferenceType }
-     * 
+     *
      */
     public XmlNoticeReferenceType createXmlNoticeReferenceType() {
         return new XmlNoticeReferenceType();
@@ -277,7 +278,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertificateValuesType }
-     * 
+     *
      */
     public XmlCertificateValuesType createXmlCertificateValuesType() {
         return new XmlCertificateValuesType();
@@ -285,7 +286,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOtherCertStatusRefsType }
-     * 
+     *
      */
     public XmlOtherCertStatusRefsType createXmlOtherCertStatusRefsType() {
         return new XmlOtherCertStatusRefsType();
@@ -293,7 +294,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlQualifyingPropertiesType }
-     * 
+     *
      */
     public XmlQualifyingPropertiesType createXmlQualifyingPropertiesType() {
         return new XmlQualifyingPropertiesType();
@@ -301,7 +302,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCommitmentTypeQualifiersListType }
-     * 
+     *
      */
     public XmlCommitmentTypeQualifiersListType createXmlCommitmentTypeQualifiersListType() {
         return new XmlCommitmentTypeQualifiersListType();
@@ -309,7 +310,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignatureProductionPlaceType }
-     * 
+     *
      */
     public XmlSignatureProductionPlaceType createXmlSignatureProductionPlaceType() {
         return new XmlSignatureProductionPlaceType();
@@ -317,7 +318,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignedSignaturePropertiesType }
-     * 
+     *
      */
     public XmlSignedSignaturePropertiesType createXmlSignedSignaturePropertiesType() {
         return new XmlSignedSignaturePropertiesType();
@@ -325,7 +326,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOtherTimeStampType }
-     * 
+     *
      */
     public XmlOtherTimeStampType createXmlOtherTimeStampType() {
         return new XmlOtherTimeStampType();
@@ -333,7 +334,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLValuesType }
-     * 
+     *
      */
     public XmlCRLValuesType createXmlCRLValuesType() {
         return new XmlCRLValuesType();
@@ -341,7 +342,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlXAdESTimeStampType }
-     * 
+     *
      */
     public XmlXAdESTimeStampType createXmlXAdESTimeStampType() {
         return new XmlXAdESTimeStampType();
@@ -349,7 +350,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSigPolicyQualifiersListType }
-     * 
+     *
      */
     public XmlSigPolicyQualifiersListType createXmlSigPolicyQualifiersListType() {
         return new XmlSigPolicyQualifiersListType();
@@ -357,7 +358,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCompleteRevocationRefsType }
-     * 
+     *
      */
     public XmlCompleteRevocationRefsType createXmlCompleteRevocationRefsType() {
         return new XmlCompleteRevocationRefsType();
@@ -365,7 +366,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPValuesType }
-     * 
+     *
      */
     public XmlOCSPValuesType createXmlOCSPValuesType() {
         return new XmlOCSPValuesType();
@@ -373,7 +374,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLIdentifierType }
-     * 
+     *
      */
     public XmlCRLIdentifierType createXmlCRLIdentifierType() {
         return new XmlCRLIdentifierType();
@@ -381,7 +382,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlClaimedRolesListType }
-     * 
+     *
      */
     public XmlClaimedRolesListType createXmlClaimedRolesListType() {
         return new XmlClaimedRolesListType();
@@ -389,7 +390,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlResponderIDType }
-     * 
+     *
      */
     public XmlResponderIDType createXmlResponderIDType() {
         return new XmlResponderIDType();
@@ -397,7 +398,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlQualifyingPropertiesReferenceType }
-     * 
+     *
      */
     public XmlQualifyingPropertiesReferenceType createXmlQualifyingPropertiesReferenceType() {
         return new XmlQualifyingPropertiesReferenceType();
@@ -405,7 +406,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOtherCertStatusValuesType }
-     * 
+     *
      */
     public XmlOtherCertStatusValuesType createXmlOtherCertStatusValuesType() {
         return new XmlOtherCertStatusValuesType();
@@ -413,7 +414,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlIncludeType }
-     * 
+     *
      */
     public XmlIncludeType createXmlIncludeType() {
         return new XmlIncludeType();
@@ -421,7 +422,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLRefsType }
-     * 
+     *
      */
     public XmlCRLRefsType createXmlCRLRefsType() {
         return new XmlCRLRefsType();
@@ -429,7 +430,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlAnyType }
-     * 
+     *
      */
     public XmlAnyType createXmlAnyType() {
         return new XmlAnyType();
@@ -437,7 +438,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignaturePolicyIdentifierType }
-     * 
+     *
      */
     public XmlSignaturePolicyIdentifierType createXmlSignaturePolicyIdentifierType() {
         return new XmlSignaturePolicyIdentifierType();
@@ -445,7 +446,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertIDType }
-     * 
+     *
      */
     public XmlCertIDType createXmlCertIDType() {
         return new XmlCertIDType();
@@ -453,7 +454,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlIntegerListType }
-     * 
+     *
      */
     public XmlIntegerListType createXmlIntegerListType() {
         return new XmlIntegerListType();
@@ -461,7 +462,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPIdentifierType }
-     * 
+     *
      */
     public XmlOCSPIdentifierType createXmlOCSPIdentifierType() {
         return new XmlOCSPIdentifierType();
@@ -469,7 +470,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlDataObjectFormatType }
-     * 
+     *
      */
     public XmlDataObjectFormatType createXmlDataObjectFormatType() {
         return new XmlDataObjectFormatType();
@@ -477,7 +478,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlValidationDataType }
-     * 
+     *
      */
     public XmlValidationDataType createXmlValidationDataType() {
         return new XmlValidationDataType();
@@ -485,250 +486,250 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlUnsignedDataObjectPropertiesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "UnsignedDataObjectProperties")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "UnsignedDataObjectProperties")
     public JAXBElement<XmlUnsignedDataObjectPropertiesType> createUnsignedDataObjectProperties(XmlUnsignedDataObjectPropertiesType value) {
         return new JAXBElement<>(_UnsignedDataObjectProperties_QNAME, XmlUnsignedDataObjectPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignatureTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignatureTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createSignatureTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SignatureTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "IndividualDataObjectsTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "IndividualDataObjectsTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createIndividualDataObjectsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_IndividualDataObjectsTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttrAuthoritiesCertValues")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttrAuthoritiesCertValues")
     public JAXBElement<XmlCertificateValuesType> createAttrAuthoritiesCertValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_AttrAuthoritiesCertValues_QNAME, XmlCertificateValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ArchiveTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ArchiveTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createArchiveTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_ArchiveTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSPUserNoticeType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SPUserNotice")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SPUserNotice")
     public JAXBElement<XmlSPUserNoticeType> createSPUserNotice(XmlSPUserNoticeType value) {
         return new JAXBElement<>(_SPUserNotice_QNAME, XmlSPUserNoticeType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlUnsignedPropertiesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "UnsignedProperties")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "UnsignedProperties")
     public JAXBElement<XmlUnsignedPropertiesType> createUnsignedProperties(XmlUnsignedPropertiesType value) {
         return new JAXBElement<>(_UnsignedProperties_QNAME, XmlUnsignedPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteRevocationRefs")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteRevocationRefs")
     public JAXBElement<XmlCompleteRevocationRefsType> createCompleteRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_CompleteRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationValues")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationValues")
     public JAXBElement<XmlRevocationValuesType> createAttributeRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_AttributeRevocationValues_QNAME, XmlRevocationValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedSignaturePropertiesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignedSignatureProperties")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignedSignatureProperties")
     public JAXBElement<XmlSignedSignaturePropertiesType> createSignedSignatureProperties(XmlSignedSignaturePropertiesType value) {
         return new JAXBElement<>(_SignedSignatureProperties_QNAME, XmlSignedSignaturePropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlObjectIdentifierType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ObjectIdentifier")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ObjectIdentifier")
     public JAXBElement<XmlObjectIdentifierType> createObjectIdentifier(XmlObjectIdentifierType value) {
         return new JAXBElement<>(_ObjectIdentifier_QNAME, XmlObjectIdentifierType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlOtherTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "OtherTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "OtherTimeStamp")
     public JAXBElement<XmlOtherTimeStampType> createOtherTimeStamp(XmlOtherTimeStampType value) {
         return new JAXBElement<>(_OtherTimeStamp_QNAME, XmlOtherTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RefsOnlyTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RefsOnlyTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createRefsOnlyTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_RefsOnlyTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SPURI")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SPURI")
     public JAXBElement<String> createSPURI(String value) {
         return new JAXBElement<>(_SPURI_QNAME, String.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedDataObjectPropertiesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignedDataObjectProperties")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignedDataObjectProperties")
     public JAXBElement<XmlSignedDataObjectPropertiesType> createSignedDataObjectProperties(XmlSignedDataObjectPropertiesType value) {
         return new JAXBElement<>(_SignedDataObjectProperties_QNAME, XmlSignedDataObjectPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCounterSignatureType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CounterSignature")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CounterSignature")
     public JAXBElement<XmlCounterSignatureType> createCounterSignature(XmlCounterSignatureType value) {
         return new JAXBElement<>(_CounterSignature_QNAME, XmlCounterSignatureType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlQualifyingPropertiesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "QualifyingProperties")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "QualifyingProperties")
     public JAXBElement<XmlQualifyingPropertiesType> createQualifyingProperties(XmlQualifyingPropertiesType value) {
         return new JAXBElement<>(_QualifyingProperties_QNAME, XmlQualifyingPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertIDListType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigningCertificate")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigningCertificate")
     public JAXBElement<XmlCertIDListType> createSigningCertificate(XmlCertIDListType value) {
         return new JAXBElement<>(_SigningCertificate_QNAME, XmlCertIDListType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlReferenceInfoType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ReferenceInfo")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ReferenceInfo")
     public JAXBElement<XmlReferenceInfoType> createReferenceInfo(XmlReferenceInfoType value) {
         return new JAXBElement<>(_ReferenceInfo_QNAME, XmlReferenceInfoType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "XAdESTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "XAdESTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createXAdESTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_XAdESTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureProductionPlaceType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignatureProductionPlace")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignatureProductionPlace")
     public JAXBElement<XmlSignatureProductionPlaceType> createSignatureProductionPlace(XmlSignatureProductionPlaceType value) {
         return new JAXBElement<>(_SignatureProductionPlace_QNAME, XmlSignatureProductionPlaceType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlEncapsulatedPKIDataType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "EncapsulatedPKIData")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "EncapsulatedPKIData")
     public JAXBElement<XmlEncapsulatedPKIDataType> createEncapsulatedPKIData(XmlEncapsulatedPKIDataType value) {
         return new JAXBElement<>(_EncapsulatedPKIData_QNAME, XmlEncapsulatedPKIDataType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlUnsignedSignaturePropertiesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "UnsignedSignatureProperties")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "UnsignedSignatureProperties")
     public JAXBElement<XmlUnsignedSignaturePropertiesType> createUnsignedSignatureProperties(XmlUnsignedSignaturePropertiesType value) {
         return new JAXBElement<>(_UnsignedSignatureProperties_QNAME, XmlUnsignedSignaturePropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCommitmentTypeIndicationType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CommitmentTypeIndication")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CommitmentTypeIndication")
     public JAXBElement<XmlCommitmentTypeIndicationType> createCommitmentTypeIndication(XmlCommitmentTypeIndicationType value) {
         return new JAXBElement<>(_CommitmentTypeIndication_QNAME, XmlCommitmentTypeIndicationType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AllDataObjectsTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AllDataObjectsTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createAllDataObjectsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_AllDataObjectsTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignerRoleType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignerRole")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignerRole")
     public JAXBElement<XmlSignerRoleType> createSignerRole(XmlSignerRoleType value) {
         return new JAXBElement<>(_SignerRole_QNAME, XmlSignerRoleType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RevocationValues")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RevocationValues")
     public JAXBElement<XmlRevocationValuesType> createRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_RevocationValues_QNAME, XmlRevocationValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
     @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.4.1#", name = "ArchiveTimeStampV2")
     public JAXBElement<XmlXAdESTimeStampType> createArchiveTimeStampV2(XmlXAdESTimeStampType value) {
@@ -737,88 +738,88 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlQualifyingPropertiesReferenceType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "QualifyingPropertiesReference")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "QualifyingPropertiesReference")
     public JAXBElement<XmlQualifyingPropertiesReferenceType> createQualifyingPropertiesReference(XmlQualifyingPropertiesReferenceType value) {
         return new JAXBElement<>(_QualifyingPropertiesReference_QNAME, XmlQualifyingPropertiesReferenceType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CertificateValues")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CertificateValues")
     public JAXBElement<XmlCertificateValuesType> createCertificateValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_CertificateValues_QNAME, XmlCertificateValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlAnyType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "Any")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "Any")
     public JAXBElement<XmlAnyType> createAny(XmlAnyType value) {
         return new JAXBElement<>(_Any_QNAME, XmlAnyType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignaturePolicyIdentifierType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignaturePolicyIdentifier")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignaturePolicyIdentifier")
     public JAXBElement<XmlSignaturePolicyIdentifierType> createSignaturePolicyIdentifier(XmlSignaturePolicyIdentifierType value) {
         return new JAXBElement<>(_SignaturePolicyIdentifier_QNAME, XmlSignaturePolicyIdentifierType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XMLGregorianCalendar }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigningTime")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigningTime")
     public JAXBElement<XMLGregorianCalendar> createSigningTime(XMLGregorianCalendar value) {
         return new JAXBElement<>(_SigningTime_QNAME, XMLGregorianCalendar.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlIncludeType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "Include")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "Include")
     public JAXBElement<XmlIncludeType> createInclude(XmlIncludeType value) {
         return new JAXBElement<>(_Include_QNAME, XmlIncludeType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigAndRefsTimeStamp")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigAndRefsTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createSigAndRefsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SigAndRefsTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlDataObjectFormatType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "DataObjectFormat")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "DataObjectFormat")
     public JAXBElement<XmlDataObjectFormatType> createDataObjectFormat(XmlDataObjectFormatType value) {
         return new JAXBElement<>(_DataObjectFormat_QNAME, XmlDataObjectFormatType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeCertificateRefs")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeCertificateRefs")
     public JAXBElement<XmlCompleteCertificateRefsType> createAttributeCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_AttributeCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlValidationDataType }{@code >}}
-     * 
+     *
      */
     @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.4.1#", name = "TimeStampValidationData")
     public JAXBElement<XmlValidationDataType> createTimeStampValidationData(XmlValidationDataType value) {
@@ -827,144 +828,144 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedPropertiesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignedProperties")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignedProperties")
     public JAXBElement<XmlSignedPropertiesType> createSignedProperties(XmlSignedPropertiesType value) {
         return new JAXBElement<>(_SignedProperties_QNAME, XmlSignedPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteCertificateRefs")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteCertificateRefs")
     public JAXBElement<XmlCompleteCertificateRefsType> createCompleteCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_CompleteCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationRefs")
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationRefs")
     public JAXBElement<XmlCompleteRevocationRefsType> createAttributeRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_AttributeRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignatureTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignatureTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeSignatureTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SignatureTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CertificateValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CertificateValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCertificateValuesType> createXmlUnsignedSignaturePropertiesTypeCertificateValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_CertificateValues_QNAME, XmlCertificateValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RefsOnlyTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RefsOnlyTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeRefsOnlyTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_RefsOnlyTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttrAuthoritiesCertValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttrAuthoritiesCertValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCertificateValuesType> createXmlUnsignedSignaturePropertiesTypeAttrAuthoritiesCertValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_AttrAuthoritiesCertValues_QNAME, XmlCertificateValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ArchiveTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ArchiveTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeArchiveTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_ArchiveTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigAndRefsTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigAndRefsTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeSigAndRefsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SigAndRefsTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCounterSignatureType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CounterSignature", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CounterSignature", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCounterSignatureType> createXmlUnsignedSignaturePropertiesTypeCounterSignature(XmlCounterSignatureType value) {
         return new JAXBElement<>(_CounterSignature_QNAME, XmlCounterSignatureType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteRevocationRefsType> createXmlUnsignedSignaturePropertiesTypeCompleteRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_CompleteRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteCertificateRefsType> createXmlUnsignedSignaturePropertiesTypeAttributeCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_AttributeCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlRevocationValuesType> createXmlUnsignedSignaturePropertiesTypeAttributeRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_AttributeRevocationValues_QNAME, XmlRevocationValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteCertificateRefsType> createXmlUnsignedSignaturePropertiesTypeCompleteCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_CompleteCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlRevocationValuesType> createXmlUnsignedSignaturePropertiesTypeRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_RevocationValues_QNAME, XmlRevocationValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     * 
+     *
      */
-    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteRevocationRefsType> createXmlUnsignedSignaturePropertiesTypeAttributeRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_AttributeRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }

--- a/src/main/java/xades4j/xml/bind/xades/ObjectFactory.java
+++ b/src/main/java/xades4j/xml/bind/xades/ObjectFactory.java
@@ -11,6 +11,7 @@ package xades4j.xml.bind.xades;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlElementDecl;
 import jakarta.xml.bind.annotation.XmlRegistry;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
@@ -32,53 +33,51 @@ import javax.xml.namespace.QName;
 @XmlRegistry
 public class ObjectFactory {
 
-    public static final String ORG_01903_V_1_3_2 = "http://uri.etsi.org/01903/v1.3.2#";
-    public static final String ORG_01903_V_1_4_1 = "http://uri.etsi.org/01903/v1.4.1#";
-    private static final QName _UnsignedDataObjectProperties_QNAME = new QName(ORG_01903_V_1_3_2, "UnsignedDataObjectProperties");
-    private static final QName _SignatureTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "SignatureTimeStamp");
-    private static final QName _IndividualDataObjectsTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "IndividualDataObjectsTimeStamp");
-    private static final QName _AttrAuthoritiesCertValues_QNAME = new QName(ORG_01903_V_1_3_2, "AttrAuthoritiesCertValues");
-    private static final QName _ArchiveTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "ArchiveTimeStamp");
-    private static final QName _SPUserNotice_QNAME = new QName(ORG_01903_V_1_3_2, "SPUserNotice");
-    private static final QName _UnsignedProperties_QNAME = new QName(ORG_01903_V_1_3_2, "UnsignedProperties");
-    private static final QName _CompleteRevocationRefs_QNAME = new QName(ORG_01903_V_1_3_2, "CompleteRevocationRefs");
-    private static final QName _AttributeRevocationValues_QNAME = new QName(ORG_01903_V_1_3_2, "AttributeRevocationValues");
-    private static final QName _SignedSignatureProperties_QNAME = new QName(ORG_01903_V_1_3_2, "SignedSignatureProperties");
-    private static final QName _ObjectIdentifier_QNAME = new QName(ORG_01903_V_1_3_2, "ObjectIdentifier");
-    private static final QName _OtherTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "OtherTimeStamp");
-    private static final QName _RefsOnlyTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "RefsOnlyTimeStamp");
-    private static final QName _SPURI_QNAME = new QName(ORG_01903_V_1_3_2, "SPURI");
-    private static final QName _SignedDataObjectProperties_QNAME = new QName(ORG_01903_V_1_3_2, "SignedDataObjectProperties");
-    private static final QName _CounterSignature_QNAME = new QName(ORG_01903_V_1_3_2, "CounterSignature");
-    private static final QName _QualifyingProperties_QNAME = new QName(ORG_01903_V_1_3_2, "QualifyingProperties");
-    private static final QName _SigningCertificate_QNAME = new QName(ORG_01903_V_1_3_2, "SigningCertificate");
-    private static final QName _ReferenceInfo_QNAME = new QName(ORG_01903_V_1_3_2, "ReferenceInfo");
-    private static final QName _XAdESTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "XAdESTimeStamp");
-    private static final QName _SignatureProductionPlace_QNAME = new QName(ORG_01903_V_1_3_2, "SignatureProductionPlace");
-    private static final QName _EncapsulatedPKIData_QNAME = new QName(ORG_01903_V_1_3_2, "EncapsulatedPKIData");
-    private static final QName _UnsignedSignatureProperties_QNAME = new QName(ORG_01903_V_1_3_2, "UnsignedSignatureProperties");
-    private static final QName _CommitmentTypeIndication_QNAME = new QName(ORG_01903_V_1_3_2, "CommitmentTypeIndication");
-    private static final QName _AllDataObjectsTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "AllDataObjectsTimeStamp");
-    private static final QName _SignerRole_QNAME = new QName(ORG_01903_V_1_3_2, "SignerRole");
-    private static final QName _RevocationValues_QNAME = new QName(ORG_01903_V_1_3_2, "RevocationValues");
-    private static final QName _ArchiveTimeStampV2_QNAME = new QName(ORG_01903_V_1_4_1, "ArchiveTimeStampV2");
-    private static final QName _QualifyingPropertiesReference_QNAME = new QName(ORG_01903_V_1_3_2, "QualifyingPropertiesReference");
-    private static final QName _CertificateValues_QNAME = new QName(ORG_01903_V_1_3_2, "CertificateValues");
-    private static final QName _Any_QNAME = new QName(ORG_01903_V_1_3_2, "Any");
-    private static final QName _SignaturePolicyIdentifier_QNAME = new QName(ORG_01903_V_1_3_2, "SignaturePolicyIdentifier");
-    private static final QName _SigningTime_QNAME = new QName(ORG_01903_V_1_3_2, "SigningTime");
-    private static final QName _Include_QNAME = new QName(ORG_01903_V_1_3_2, "Include");
-    private static final QName _SigAndRefsTimeStamp_QNAME = new QName(ORG_01903_V_1_3_2, "SigAndRefsTimeStamp");
-    private static final QName _DataObjectFormat_QNAME = new QName(ORG_01903_V_1_3_2, "DataObjectFormat");
-    private static final QName _AttributeCertificateRefs_QNAME = new QName(ORG_01903_V_1_3_2, "AttributeCertificateRefs");
-    private static final QName _TimeStampValidationData_QNAME = new QName("ORG_01903_V_1_4_1", "TimeStampValidationData");
-    private static final QName _SignedProperties_QNAME = new QName(ORG_01903_V_1_3_2, "SignedProperties");
-    private static final QName _CompleteCertificateRefs_QNAME = new QName(ORG_01903_V_1_3_2, "CompleteCertificateRefs");
-    private static final QName _AttributeRevocationRefs_QNAME = new QName(ORG_01903_V_1_3_2, "AttributeRevocationRefs");
+    private static final QName _UnsignedDataObjectProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "UnsignedDataObjectProperties");
+    private static final QName _SignatureTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignatureTimeStamp");
+    private static final QName _IndividualDataObjectsTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "IndividualDataObjectsTimeStamp");
+    private static final QName _AttrAuthoritiesCertValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttrAuthoritiesCertValues");
+    private static final QName _ArchiveTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "ArchiveTimeStamp");
+    private static final QName _SPUserNotice_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SPUserNotice");
+    private static final QName _UnsignedProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "UnsignedProperties");
+    private static final QName _CompleteRevocationRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CompleteRevocationRefs");
+    private static final QName _AttributeRevocationValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttributeRevocationValues");
+    private static final QName _SignedSignatureProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignedSignatureProperties");
+    private static final QName _ObjectIdentifier_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "ObjectIdentifier");
+    private static final QName _OtherTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "OtherTimeStamp");
+    private static final QName _RefsOnlyTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "RefsOnlyTimeStamp");
+    private static final QName _SPURI_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SPURI");
+    private static final QName _SignedDataObjectProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignedDataObjectProperties");
+    private static final QName _CounterSignature_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CounterSignature");
+    private static final QName _QualifyingProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "QualifyingProperties");
+    private static final QName _SigningCertificate_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SigningCertificate");
+    private static final QName _ReferenceInfo_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "ReferenceInfo");
+    private static final QName _XAdESTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "XAdESTimeStamp");
+    private static final QName _SignatureProductionPlace_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignatureProductionPlace");
+    private static final QName _EncapsulatedPKIData_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "EncapsulatedPKIData");
+    private static final QName _UnsignedSignatureProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "UnsignedSignatureProperties");
+    private static final QName _CommitmentTypeIndication_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CommitmentTypeIndication");
+    private static final QName _AllDataObjectsTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AllDataObjectsTimeStamp");
+    private static final QName _SignerRole_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignerRole");
+    private static final QName _RevocationValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "RevocationValues");
+    private static final QName _ArchiveTimeStampV2_QNAME = new QName("http://uri.etsi.org/01903/v1.4.1#", "ArchiveTimeStampV2");
+    private static final QName _QualifyingPropertiesReference_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "QualifyingPropertiesReference");
+    private static final QName _CertificateValues_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CertificateValues");
+    private static final QName _Any_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "Any");
+    private static final QName _SignaturePolicyIdentifier_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignaturePolicyIdentifier");
+    private static final QName _SigningTime_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SigningTime");
+    private static final QName _Include_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "Include");
+    private static final QName _SigAndRefsTimeStamp_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SigAndRefsTimeStamp");
+    private static final QName _DataObjectFormat_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "DataObjectFormat");
+    private static final QName _AttributeCertificateRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttributeCertificateRefs");
+    private static final QName _TimeStampValidationData_QNAME = new QName("http://uri.etsi.org/01903/v1.4.1#", "TimeStampValidationData");
+    private static final QName _SignedProperties_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "SignedProperties");
+    private static final QName _CompleteCertificateRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "CompleteCertificateRefs");
+    private static final QName _AttributeRevocationRefs_QNAME = new QName("http://uri.etsi.org/01903/v1.3.2#", "AttributeRevocationRefs");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: xades4j.marshalling.xades
-     *
+     * 
      */
     public ObjectFactory() {
         // TODO document why this constructor is empty
@@ -86,7 +85,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertifiedRolesListType }
-     *
+     * 
      */
     public XmlCertifiedRolesListType createXmlCertifiedRolesListType() {
         return new XmlCertifiedRolesListType();
@@ -94,7 +93,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCommitmentTypeIndicationType }
-     *
+     * 
      */
     public XmlCommitmentTypeIndicationType createXmlCommitmentTypeIndicationType() {
         return new XmlCommitmentTypeIndicationType();
@@ -102,7 +101,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlRevocationValuesType }
-     *
+     * 
      */
     public XmlRevocationValuesType createXmlRevocationValuesType() {
         return new XmlRevocationValuesType();
@@ -110,7 +109,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlDocumentationReferencesType }
-     *
+     * 
      */
     public XmlDocumentationReferencesType createXmlDocumentationReferencesType() {
         return new XmlDocumentationReferencesType();
@@ -118,7 +117,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSPUserNoticeType }
-     *
+     * 
      */
     public XmlSPUserNoticeType createXmlSPUserNoticeType() {
         return new XmlSPUserNoticeType();
@@ -126,7 +125,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertIDListType }
-     *
+     * 
      */
     public XmlCertIDListType createXmlCertIDListType() {
         return new XmlCertIDListType();
@@ -134,7 +133,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignedPropertiesType }
-     *
+     * 
      */
     public XmlSignedPropertiesType createXmlSignedPropertiesType() {
         return new XmlSignedPropertiesType();
@@ -142,7 +141,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignaturePolicyIdType }
-     *
+     * 
      */
     public XmlSignaturePolicyIdType createXmlSignaturePolicyIdType() {
         return new XmlSignaturePolicyIdType();
@@ -150,7 +149,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlReferenceInfoType }
-     *
+     * 
      */
     public XmlReferenceInfoType createXmlReferenceInfoType() {
         return new XmlReferenceInfoType();
@@ -158,7 +157,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPRefsType }
-     *
+     * 
      */
     public XmlOCSPRefsType createXmlOCSPRefsType() {
         return new XmlOCSPRefsType();
@@ -166,7 +165,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlEncapsulatedPKIDataType }
-     *
+     * 
      */
     public XmlEncapsulatedPKIDataType createXmlEncapsulatedPKIDataType() {
         return new XmlEncapsulatedPKIDataType();
@@ -174,7 +173,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCompleteCertificateRefsType }
-     *
+     * 
      */
     public XmlCompleteCertificateRefsType createXmlCompleteCertificateRefsType() {
         return new XmlCompleteCertificateRefsType();
@@ -182,7 +181,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlDigestAlgAndValueType }
-     *
+     * 
      */
     public XmlDigestAlgAndValueType createXmlDigestAlgAndValueType() {
         return new XmlDigestAlgAndValueType();
@@ -190,7 +189,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlObjectIdentifierType }
-     *
+     * 
      */
     public XmlObjectIdentifierType createXmlObjectIdentifierType() {
         return new XmlObjectIdentifierType();
@@ -198,7 +197,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPRefType }
-     *
+     * 
      */
     public XmlOCSPRefType createXmlOCSPRefType() {
         return new XmlOCSPRefType();
@@ -206,7 +205,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLRefType }
-     *
+     * 
      */
     public XmlCRLRefType createXmlCRLRefType() {
         return new XmlCRLRefType();
@@ -214,7 +213,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlUnsignedSignaturePropertiesType }
-     *
+     * 
      */
     public XmlUnsignedSignaturePropertiesType createXmlUnsignedSignaturePropertiesType() {
         return new XmlUnsignedSignaturePropertiesType();
@@ -222,7 +221,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignerRoleType }
-     *
+     * 
      */
     public XmlSignerRoleType createXmlSignerRoleType() {
         return new XmlSignerRoleType();
@@ -230,7 +229,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlUnsignedDataObjectPropertiesType }
-     *
+     * 
      */
     public XmlUnsignedDataObjectPropertiesType createXmlUnsignedDataObjectPropertiesType() {
         return new XmlUnsignedDataObjectPropertiesType();
@@ -238,7 +237,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlIdentifierType }
-     *
+     * 
      */
     public XmlIdentifierType createXmlIdentifierType() {
         return new XmlIdentifierType();
@@ -246,7 +245,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCounterSignatureType }
-     *
+     * 
      */
     public XmlCounterSignatureType createXmlCounterSignatureType() {
         return new XmlCounterSignatureType();
@@ -254,7 +253,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignedDataObjectPropertiesType }
-     *
+     * 
      */
     public XmlSignedDataObjectPropertiesType createXmlSignedDataObjectPropertiesType() {
         return new XmlSignedDataObjectPropertiesType();
@@ -262,7 +261,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlUnsignedPropertiesType }
-     *
+     * 
      */
     public XmlUnsignedPropertiesType createXmlUnsignedPropertiesType() {
         return new XmlUnsignedPropertiesType();
@@ -270,7 +269,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlNoticeReferenceType }
-     *
+     * 
      */
     public XmlNoticeReferenceType createXmlNoticeReferenceType() {
         return new XmlNoticeReferenceType();
@@ -278,7 +277,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertificateValuesType }
-     *
+     * 
      */
     public XmlCertificateValuesType createXmlCertificateValuesType() {
         return new XmlCertificateValuesType();
@@ -286,7 +285,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOtherCertStatusRefsType }
-     *
+     * 
      */
     public XmlOtherCertStatusRefsType createXmlOtherCertStatusRefsType() {
         return new XmlOtherCertStatusRefsType();
@@ -294,7 +293,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlQualifyingPropertiesType }
-     *
+     * 
      */
     public XmlQualifyingPropertiesType createXmlQualifyingPropertiesType() {
         return new XmlQualifyingPropertiesType();
@@ -302,7 +301,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCommitmentTypeQualifiersListType }
-     *
+     * 
      */
     public XmlCommitmentTypeQualifiersListType createXmlCommitmentTypeQualifiersListType() {
         return new XmlCommitmentTypeQualifiersListType();
@@ -310,7 +309,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignatureProductionPlaceType }
-     *
+     * 
      */
     public XmlSignatureProductionPlaceType createXmlSignatureProductionPlaceType() {
         return new XmlSignatureProductionPlaceType();
@@ -318,7 +317,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignedSignaturePropertiesType }
-     *
+     * 
      */
     public XmlSignedSignaturePropertiesType createXmlSignedSignaturePropertiesType() {
         return new XmlSignedSignaturePropertiesType();
@@ -326,7 +325,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOtherTimeStampType }
-     *
+     * 
      */
     public XmlOtherTimeStampType createXmlOtherTimeStampType() {
         return new XmlOtherTimeStampType();
@@ -334,7 +333,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLValuesType }
-     *
+     * 
      */
     public XmlCRLValuesType createXmlCRLValuesType() {
         return new XmlCRLValuesType();
@@ -342,7 +341,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlXAdESTimeStampType }
-     *
+     * 
      */
     public XmlXAdESTimeStampType createXmlXAdESTimeStampType() {
         return new XmlXAdESTimeStampType();
@@ -350,7 +349,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSigPolicyQualifiersListType }
-     *
+     * 
      */
     public XmlSigPolicyQualifiersListType createXmlSigPolicyQualifiersListType() {
         return new XmlSigPolicyQualifiersListType();
@@ -358,7 +357,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCompleteRevocationRefsType }
-     *
+     * 
      */
     public XmlCompleteRevocationRefsType createXmlCompleteRevocationRefsType() {
         return new XmlCompleteRevocationRefsType();
@@ -366,7 +365,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPValuesType }
-     *
+     * 
      */
     public XmlOCSPValuesType createXmlOCSPValuesType() {
         return new XmlOCSPValuesType();
@@ -374,7 +373,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLIdentifierType }
-     *
+     * 
      */
     public XmlCRLIdentifierType createXmlCRLIdentifierType() {
         return new XmlCRLIdentifierType();
@@ -382,7 +381,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlClaimedRolesListType }
-     *
+     * 
      */
     public XmlClaimedRolesListType createXmlClaimedRolesListType() {
         return new XmlClaimedRolesListType();
@@ -390,7 +389,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlResponderIDType }
-     *
+     * 
      */
     public XmlResponderIDType createXmlResponderIDType() {
         return new XmlResponderIDType();
@@ -398,7 +397,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlQualifyingPropertiesReferenceType }
-     *
+     * 
      */
     public XmlQualifyingPropertiesReferenceType createXmlQualifyingPropertiesReferenceType() {
         return new XmlQualifyingPropertiesReferenceType();
@@ -406,7 +405,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOtherCertStatusValuesType }
-     *
+     * 
      */
     public XmlOtherCertStatusValuesType createXmlOtherCertStatusValuesType() {
         return new XmlOtherCertStatusValuesType();
@@ -414,7 +413,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlIncludeType }
-     *
+     * 
      */
     public XmlIncludeType createXmlIncludeType() {
         return new XmlIncludeType();
@@ -422,7 +421,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCRLRefsType }
-     *
+     * 
      */
     public XmlCRLRefsType createXmlCRLRefsType() {
         return new XmlCRLRefsType();
@@ -430,7 +429,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlAnyType }
-     *
+     * 
      */
     public XmlAnyType createXmlAnyType() {
         return new XmlAnyType();
@@ -438,7 +437,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlSignaturePolicyIdentifierType }
-     *
+     * 
      */
     public XmlSignaturePolicyIdentifierType createXmlSignaturePolicyIdentifierType() {
         return new XmlSignaturePolicyIdentifierType();
@@ -446,7 +445,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlCertIDType }
-     *
+     * 
      */
     public XmlCertIDType createXmlCertIDType() {
         return new XmlCertIDType();
@@ -454,7 +453,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlIntegerListType }
-     *
+     * 
      */
     public XmlIntegerListType createXmlIntegerListType() {
         return new XmlIntegerListType();
@@ -462,7 +461,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlOCSPIdentifierType }
-     *
+     * 
      */
     public XmlOCSPIdentifierType createXmlOCSPIdentifierType() {
         return new XmlOCSPIdentifierType();
@@ -470,7 +469,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlDataObjectFormatType }
-     *
+     * 
      */
     public XmlDataObjectFormatType createXmlDataObjectFormatType() {
         return new XmlDataObjectFormatType();
@@ -478,7 +477,7 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link XmlValidationDataType }
-     *
+     * 
      */
     public XmlValidationDataType createXmlValidationDataType() {
         return new XmlValidationDataType();
@@ -486,250 +485,250 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlUnsignedDataObjectPropertiesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "UnsignedDataObjectProperties")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "UnsignedDataObjectProperties")
     public JAXBElement<XmlUnsignedDataObjectPropertiesType> createUnsignedDataObjectProperties(XmlUnsignedDataObjectPropertiesType value) {
         return new JAXBElement<>(_UnsignedDataObjectProperties_QNAME, XmlUnsignedDataObjectPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignatureTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignatureTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createSignatureTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SignatureTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "IndividualDataObjectsTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "IndividualDataObjectsTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createIndividualDataObjectsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_IndividualDataObjectsTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttrAuthoritiesCertValues")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttrAuthoritiesCertValues")
     public JAXBElement<XmlCertificateValuesType> createAttrAuthoritiesCertValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_AttrAuthoritiesCertValues_QNAME, XmlCertificateValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ArchiveTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ArchiveTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createArchiveTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_ArchiveTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSPUserNoticeType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SPUserNotice")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SPUserNotice")
     public JAXBElement<XmlSPUserNoticeType> createSPUserNotice(XmlSPUserNoticeType value) {
         return new JAXBElement<>(_SPUserNotice_QNAME, XmlSPUserNoticeType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlUnsignedPropertiesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "UnsignedProperties")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "UnsignedProperties")
     public JAXBElement<XmlUnsignedPropertiesType> createUnsignedProperties(XmlUnsignedPropertiesType value) {
         return new JAXBElement<>(_UnsignedProperties_QNAME, XmlUnsignedPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteRevocationRefs")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteRevocationRefs")
     public JAXBElement<XmlCompleteRevocationRefsType> createCompleteRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_CompleteRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationValues")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationValues")
     public JAXBElement<XmlRevocationValuesType> createAttributeRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_AttributeRevocationValues_QNAME, XmlRevocationValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedSignaturePropertiesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignedSignatureProperties")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignedSignatureProperties")
     public JAXBElement<XmlSignedSignaturePropertiesType> createSignedSignatureProperties(XmlSignedSignaturePropertiesType value) {
         return new JAXBElement<>(_SignedSignatureProperties_QNAME, XmlSignedSignaturePropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlObjectIdentifierType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ObjectIdentifier")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ObjectIdentifier")
     public JAXBElement<XmlObjectIdentifierType> createObjectIdentifier(XmlObjectIdentifierType value) {
         return new JAXBElement<>(_ObjectIdentifier_QNAME, XmlObjectIdentifierType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlOtherTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "OtherTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "OtherTimeStamp")
     public JAXBElement<XmlOtherTimeStampType> createOtherTimeStamp(XmlOtherTimeStampType value) {
         return new JAXBElement<>(_OtherTimeStamp_QNAME, XmlOtherTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RefsOnlyTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RefsOnlyTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createRefsOnlyTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_RefsOnlyTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SPURI")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SPURI")
     public JAXBElement<String> createSPURI(String value) {
         return new JAXBElement<>(_SPURI_QNAME, String.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedDataObjectPropertiesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignedDataObjectProperties")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignedDataObjectProperties")
     public JAXBElement<XmlSignedDataObjectPropertiesType> createSignedDataObjectProperties(XmlSignedDataObjectPropertiesType value) {
         return new JAXBElement<>(_SignedDataObjectProperties_QNAME, XmlSignedDataObjectPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCounterSignatureType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CounterSignature")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CounterSignature")
     public JAXBElement<XmlCounterSignatureType> createCounterSignature(XmlCounterSignatureType value) {
         return new JAXBElement<>(_CounterSignature_QNAME, XmlCounterSignatureType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlQualifyingPropertiesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "QualifyingProperties")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "QualifyingProperties")
     public JAXBElement<XmlQualifyingPropertiesType> createQualifyingProperties(XmlQualifyingPropertiesType value) {
         return new JAXBElement<>(_QualifyingProperties_QNAME, XmlQualifyingPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertIDListType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigningCertificate")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigningCertificate")
     public JAXBElement<XmlCertIDListType> createSigningCertificate(XmlCertIDListType value) {
         return new JAXBElement<>(_SigningCertificate_QNAME, XmlCertIDListType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlReferenceInfoType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ReferenceInfo")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ReferenceInfo")
     public JAXBElement<XmlReferenceInfoType> createReferenceInfo(XmlReferenceInfoType value) {
         return new JAXBElement<>(_ReferenceInfo_QNAME, XmlReferenceInfoType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "XAdESTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "XAdESTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createXAdESTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_XAdESTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureProductionPlaceType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignatureProductionPlace")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignatureProductionPlace")
     public JAXBElement<XmlSignatureProductionPlaceType> createSignatureProductionPlace(XmlSignatureProductionPlaceType value) {
         return new JAXBElement<>(_SignatureProductionPlace_QNAME, XmlSignatureProductionPlaceType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlEncapsulatedPKIDataType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "EncapsulatedPKIData")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "EncapsulatedPKIData")
     public JAXBElement<XmlEncapsulatedPKIDataType> createEncapsulatedPKIData(XmlEncapsulatedPKIDataType value) {
         return new JAXBElement<>(_EncapsulatedPKIData_QNAME, XmlEncapsulatedPKIDataType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlUnsignedSignaturePropertiesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "UnsignedSignatureProperties")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "UnsignedSignatureProperties")
     public JAXBElement<XmlUnsignedSignaturePropertiesType> createUnsignedSignatureProperties(XmlUnsignedSignaturePropertiesType value) {
         return new JAXBElement<>(_UnsignedSignatureProperties_QNAME, XmlUnsignedSignaturePropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCommitmentTypeIndicationType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CommitmentTypeIndication")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CommitmentTypeIndication")
     public JAXBElement<XmlCommitmentTypeIndicationType> createCommitmentTypeIndication(XmlCommitmentTypeIndicationType value) {
         return new JAXBElement<>(_CommitmentTypeIndication_QNAME, XmlCommitmentTypeIndicationType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AllDataObjectsTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AllDataObjectsTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createAllDataObjectsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_AllDataObjectsTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignerRoleType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignerRole")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignerRole")
     public JAXBElement<XmlSignerRoleType> createSignerRole(XmlSignerRoleType value) {
         return new JAXBElement<>(_SignerRole_QNAME, XmlSignerRoleType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RevocationValues")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RevocationValues")
     public JAXBElement<XmlRevocationValuesType> createRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_RevocationValues_QNAME, XmlRevocationValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
     @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.4.1#", name = "ArchiveTimeStampV2")
     public JAXBElement<XmlXAdESTimeStampType> createArchiveTimeStampV2(XmlXAdESTimeStampType value) {
@@ -738,88 +737,88 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlQualifyingPropertiesReferenceType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "QualifyingPropertiesReference")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "QualifyingPropertiesReference")
     public JAXBElement<XmlQualifyingPropertiesReferenceType> createQualifyingPropertiesReference(XmlQualifyingPropertiesReferenceType value) {
         return new JAXBElement<>(_QualifyingPropertiesReference_QNAME, XmlQualifyingPropertiesReferenceType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CertificateValues")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CertificateValues")
     public JAXBElement<XmlCertificateValuesType> createCertificateValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_CertificateValues_QNAME, XmlCertificateValuesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlAnyType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "Any")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "Any")
     public JAXBElement<XmlAnyType> createAny(XmlAnyType value) {
         return new JAXBElement<>(_Any_QNAME, XmlAnyType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignaturePolicyIdentifierType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignaturePolicyIdentifier")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignaturePolicyIdentifier")
     public JAXBElement<XmlSignaturePolicyIdentifierType> createSignaturePolicyIdentifier(XmlSignaturePolicyIdentifierType value) {
         return new JAXBElement<>(_SignaturePolicyIdentifier_QNAME, XmlSignaturePolicyIdentifierType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XMLGregorianCalendar }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigningTime")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigningTime")
     public JAXBElement<XMLGregorianCalendar> createSigningTime(XMLGregorianCalendar value) {
         return new JAXBElement<>(_SigningTime_QNAME, XMLGregorianCalendar.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlIncludeType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "Include")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "Include")
     public JAXBElement<XmlIncludeType> createInclude(XmlIncludeType value) {
         return new JAXBElement<>(_Include_QNAME, XmlIncludeType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigAndRefsTimeStamp")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigAndRefsTimeStamp")
     public JAXBElement<XmlXAdESTimeStampType> createSigAndRefsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SigAndRefsTimeStamp_QNAME, XmlXAdESTimeStampType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlDataObjectFormatType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "DataObjectFormat")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "DataObjectFormat")
     public JAXBElement<XmlDataObjectFormatType> createDataObjectFormat(XmlDataObjectFormatType value) {
         return new JAXBElement<>(_DataObjectFormat_QNAME, XmlDataObjectFormatType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeCertificateRefs")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeCertificateRefs")
     public JAXBElement<XmlCompleteCertificateRefsType> createAttributeCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_AttributeCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlValidationDataType }{@code >}}
-     *
+     * 
      */
     @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.4.1#", name = "TimeStampValidationData")
     public JAXBElement<XmlValidationDataType> createTimeStampValidationData(XmlValidationDataType value) {
@@ -828,144 +827,144 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedPropertiesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignedProperties")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignedProperties")
     public JAXBElement<XmlSignedPropertiesType> createSignedProperties(XmlSignedPropertiesType value) {
         return new JAXBElement<>(_SignedProperties_QNAME, XmlSignedPropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteCertificateRefs")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteCertificateRefs")
     public JAXBElement<XmlCompleteCertificateRefsType> createCompleteCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_CompleteCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationRefs")
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationRefs")
     public JAXBElement<XmlCompleteRevocationRefsType> createAttributeRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_AttributeRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SignatureTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SignatureTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeSignatureTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SignatureTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CertificateValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CertificateValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCertificateValuesType> createXmlUnsignedSignaturePropertiesTypeCertificateValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_CertificateValues_QNAME, XmlCertificateValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RefsOnlyTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RefsOnlyTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeRefsOnlyTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_RefsOnlyTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCertificateValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttrAuthoritiesCertValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttrAuthoritiesCertValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCertificateValuesType> createXmlUnsignedSignaturePropertiesTypeAttrAuthoritiesCertValues(XmlCertificateValuesType value) {
         return new JAXBElement<>(_AttrAuthoritiesCertValues_QNAME, XmlCertificateValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "ArchiveTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "ArchiveTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeArchiveTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_ArchiveTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlXAdESTimeStampType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "SigAndRefsTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "SigAndRefsTimeStamp", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlXAdESTimeStampType> createXmlUnsignedSignaturePropertiesTypeSigAndRefsTimeStamp(XmlXAdESTimeStampType value) {
         return new JAXBElement<>(_SigAndRefsTimeStamp_QNAME, XmlXAdESTimeStampType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCounterSignatureType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CounterSignature", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CounterSignature", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCounterSignatureType> createXmlUnsignedSignaturePropertiesTypeCounterSignature(XmlCounterSignatureType value) {
         return new JAXBElement<>(_CounterSignature_QNAME, XmlCounterSignatureType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteRevocationRefsType> createXmlUnsignedSignaturePropertiesTypeCompleteRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_CompleteRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteCertificateRefsType> createXmlUnsignedSignaturePropertiesTypeAttributeCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_AttributeCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlRevocationValuesType> createXmlUnsignedSignaturePropertiesTypeAttributeRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_AttributeRevocationValues_QNAME, XmlRevocationValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteCertificateRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "CompleteCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "CompleteCertificateRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteCertificateRefsType> createXmlUnsignedSignaturePropertiesTypeCompleteCertificateRefs(XmlCompleteCertificateRefsType value) {
         return new JAXBElement<>(_CompleteCertificateRefs_QNAME, XmlCompleteCertificateRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRevocationValuesType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "RevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "RevocationValues", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlRevocationValuesType> createXmlUnsignedSignaturePropertiesTypeRevocationValues(XmlRevocationValuesType value) {
         return new JAXBElement<>(_RevocationValues_QNAME, XmlRevocationValuesType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCompleteRevocationRefsType }{@code >}}
-     *
+     * 
      */
-    @XmlElementDecl(namespace = ORG_01903_V_1_3_2, name = "AttributeRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
+    @XmlElementDecl(namespace = "http://uri.etsi.org/01903/v1.3.2#", name = "AttributeRevocationRefs", scope = XmlUnsignedSignaturePropertiesType.class)
     public JAXBElement<XmlCompleteRevocationRefsType> createXmlUnsignedSignaturePropertiesTypeAttributeRevocationRefs(XmlCompleteRevocationRefsType value) {
         return new JAXBElement<>(_AttributeRevocationRefs_QNAME, XmlCompleteRevocationRefsType.class, XmlUnsignedSignaturePropertiesType.class, value);
     }

--- a/src/main/java/xades4j/xml/bind/xades/XmlAnyType.java
+++ b/src/main/java/xades4j/xml/bind/xades/XmlAnyType.java
@@ -8,16 +8,16 @@
 
 package xades4j.xml.bind.xades;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAnyAttribute;
 import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlMixed;
 import jakarta.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.xml.namespace.QName;
 import org.w3c.dom.Element;
 
@@ -52,14 +52,14 @@ public class XmlAnyType {
     @XmlAnyElement(lax = true)
     protected List<Object> content;
     @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<>();
+    private final Map<QName, String> otherAttributes = new HashMap<>();
 
     /**
      * Gets the value of the content property.
      * 
      * <p>
      * This accessor method returns a reference to the live list,
-     * not a snapshot. Therefore any modification you make to the
+     * not a snapshot. Therefore, any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
      * 

--- a/src/main/java/xades4j/xml/bind/xades/XmlIntegerListType.java
+++ b/src/main/java/xades4j/xml/bind/xades/XmlIntegerListType.java
@@ -12,6 +12,7 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,19 +39,19 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "IntegerListType", propOrder = {
-    "bigIntegers"
+    "_int"
 })
 public class XmlIntegerListType {
 
     @XmlElement(name = "int")
-    protected List<BigInteger> bigIntegers;
+    protected List<BigInteger> _int;
 
     /**
      * Gets the value of the int property.
      * 
      * <p>
      * This accessor method returns a reference to the live list,
-     * not a snapshot. Therefore, any modification you make to the
+     * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the int property.
      * 
@@ -68,10 +69,10 @@ public class XmlIntegerListType {
      * 
      */
     public List<BigInteger> getInt() {
-        if (bigIntegers == null) {
-            bigIntegers = new ArrayList<>();
+        if (_int == null) {
+            _int = new ArrayList<>();
         }
-        return this.bigIntegers;
+        return this._int;
     }
 
 }

--- a/src/main/java/xades4j/xml/bind/xades/XmlIntegerListType.java
+++ b/src/main/java/xades4j/xml/bind/xades/XmlIntegerListType.java
@@ -12,7 +12,6 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
-
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,19 +38,19 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "IntegerListType", propOrder = {
-    "_int"
+    "bigIntegers"
 })
 public class XmlIntegerListType {
 
     @XmlElement(name = "int")
-    protected List<BigInteger> _int;
+    protected List<BigInteger> bigIntegers;
 
     /**
      * Gets the value of the int property.
      * 
      * <p>
      * This accessor method returns a reference to the live list,
-     * not a snapshot. Therefore any modification you make to the
+     * not a snapshot. Therefore, any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the int property.
      * 
@@ -69,10 +68,10 @@ public class XmlIntegerListType {
      * 
      */
     public List<BigInteger> getInt() {
-        if (_int == null) {
-            _int = new ArrayList<>();
+        if (bigIntegers == null) {
+            bigIntegers = new ArrayList<>();
         }
-        return this._int;
+        return this.bigIntegers;
     }
 
 }

--- a/src/main/java/xades4j/xml/bind/xades/XmlQualifierType.java
+++ b/src/main/java/xades4j/xml/bind/xades/XmlQualifierType.java
@@ -35,7 +35,13 @@ public enum XmlQualifierType {
     @XmlEnumValue("OIDAsURI")
     OID_AS_URI("OIDAsURI"),
     @XmlEnumValue("OIDAsURN")
-    OID_AS_URN("OIDAsURN");
+    OID_AS_URN("OIDAsURN"),
+    @Deprecated(since="2.2.2")
+    @XmlEnumValue("OIDAsURI")
+    OIDAsURI("OIDAsURI"),
+    @Deprecated(since="2.2.2")
+    @XmlEnumValue("OIDAsURN")
+    OIDAsURN("OIDAsURN");
     private final String value;
 
     XmlQualifierType(String v) {

--- a/src/main/java/xades4j/xml/bind/xmldsig/ObjectFactory.java
+++ b/src/main/java/xades4j/xml/bind/xmldsig/ObjectFactory.java
@@ -12,9 +12,10 @@ import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlElementDecl;
 import jakarta.xml.bind.annotation.XmlRegistry;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.math.BigInteger;
-import javax.xml.namespace.QName;
 import xades4j.xml.bind.Base64XmlAdapter;
+
+import javax.xml.namespace.QName;
+import java.math.BigInteger;
 
 
 /**
@@ -34,41 +35,40 @@ import xades4j.xml.bind.Base64XmlAdapter;
 @XmlRegistry
 public class ObjectFactory {
 
-    public static final String ORG_2000_09_XMLDSIG = "http://www.w3.org/2000/09/xmldsig#";
-    private static final QName _PGPData_QNAME = new QName(ORG_2000_09_XMLDSIG, "PGPData");
-    private static final QName _SPKIData_QNAME = new QName(ORG_2000_09_XMLDSIG, "SPKIData");
-    private static final QName _RetrievalMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "RetrievalMethod");
-    private static final QName _CanonicalizationMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "CanonicalizationMethod");
-    private static final QName _SignatureProperty_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureProperty");
-    private static final QName _Transforms_QNAME = new QName(ORG_2000_09_XMLDSIG, "Transforms");
-    private static final QName _Manifest_QNAME = new QName(ORG_2000_09_XMLDSIG, "Manifest");
-    private static final QName _SignatureMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureMethod");
-    private static final QName _KeyInfo_QNAME = new QName(ORG_2000_09_XMLDSIG, "KeyInfo");
-    private static final QName _DigestMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "DigestMethod");
-    private static final QName _MgmtData_QNAME = new QName(ORG_2000_09_XMLDSIG, "MgmtData");
-    private static final QName _Reference_QNAME = new QName(ORG_2000_09_XMLDSIG, "Reference");
-    private static final QName _RSAKeyValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "RSAKeyValue");
-    private static final QName _Signature_QNAME = new QName(ORG_2000_09_XMLDSIG, "Signature");
-    private static final QName _DSAKeyValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "DSAKeyValue");
-    private static final QName _SignedInfo_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignedInfo");
-    private static final QName _Object_QNAME = new QName(ORG_2000_09_XMLDSIG, "Object");
-    private static final QName _SignatureValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureValue");
-    private static final QName _Transform_QNAME = new QName(ORG_2000_09_XMLDSIG, "Transform");
-    private static final QName _X509Data_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509Data");
-    private static final QName _DigestValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "DigestValue");
-    private static final QName _SignatureProperties_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureProperties");
-    private static final QName _KeyName_QNAME = new QName(ORG_2000_09_XMLDSIG, "KeyName");
-    private static final QName _KeyValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "KeyValue");
-    private static final QName _XmlX509DataTypeX509IssuerSerial_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509IssuerSerial");
-    private static final QName _XmlX509DataTypeX509Certificate_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509Certificate");
-    private static final QName _XmlX509DataTypeX509SKI_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509SKI");
-    private static final QName _XmlX509DataTypeX509SubjectName_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509SubjectName");
-    private static final QName _XmlX509DataTypeX509CRL_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509CRL");
-    private static final QName _XmlSignatureMethodTypeHMACOutputLength_QNAME = new QName(ORG_2000_09_XMLDSIG, "HMACOutputLength");
-    private static final QName _XmlPGPDataTypePGPKeyID_QNAME = new QName(ORG_2000_09_XMLDSIG, "PGPKeyID");
-    private static final QName _XmlPGPDataTypePGPKeyPacket_QNAME = new QName(ORG_2000_09_XMLDSIG, "PGPKeyPacket");
-    private static final QName _XmlTransformTypeXPath_QNAME = new QName(ORG_2000_09_XMLDSIG, "XPath");
-    private static final QName _XmlSPKIDataTypeSPKISexp_QNAME = new QName(ORG_2000_09_XMLDSIG, "SPKISexp");
+    private static final QName _PGPData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPData");
+    private static final QName _SPKIData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SPKIData");
+    private static final QName _RetrievalMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "RetrievalMethod");
+    private static final QName _CanonicalizationMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "CanonicalizationMethod");
+    private static final QName _SignatureProperty_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperty");
+    private static final QName _Transforms_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Transforms");
+    private static final QName _Manifest_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Manifest");
+    private static final QName _SignatureMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureMethod");
+    private static final QName _KeyInfo_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyInfo");
+    private static final QName _DigestMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DigestMethod");
+    private static final QName _MgmtData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "MgmtData");
+    private static final QName _Reference_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Reference");
+    private static final QName _RSAKeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "RSAKeyValue");
+    private static final QName _Signature_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Signature");
+    private static final QName _DSAKeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DSAKeyValue");
+    private static final QName _SignedInfo_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignedInfo");
+    private static final QName _Object_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Object");
+    private static final QName _SignatureValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureValue");
+    private static final QName _Transform_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Transform");
+    private static final QName _X509Data_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509Data");
+    private static final QName _DigestValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DigestValue");
+    private static final QName _SignatureProperties_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperties");
+    private static final QName _KeyName_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyName");
+    private static final QName _KeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyValue");
+    private static final QName _XmlX509DataTypeX509IssuerSerial_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509IssuerSerial");
+    private static final QName _XmlX509DataTypeX509Certificate_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509Certificate");
+    private static final QName _XmlX509DataTypeX509SKI_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509SKI");
+    private static final QName _XmlX509DataTypeX509SubjectName_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509SubjectName");
+    private static final QName _XmlX509DataTypeX509CRL_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509CRL");
+    private static final QName _XmlSignatureMethodTypeHMACOutputLength_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "HMACOutputLength");
+    private static final QName _XmlPGPDataTypePGPKeyID_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyID");
+    private static final QName _XmlPGPDataTypePGPKeyPacket_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyPacket");
+    private static final QName _XmlTransformTypeXPath_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "XPath");
+    private static final QName _XmlSPKIDataTypeSPKISexp_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SPKISexp");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: xades4j.marshalling.xmldsig
@@ -258,7 +258,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlPGPDataType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "PGPData")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPData")
     public JAXBElement<XmlPGPDataType> createPGPData(XmlPGPDataType value) {
         return new JAXBElement<>(_PGPData_QNAME, XmlPGPDataType.class, null, value);
     }
@@ -267,7 +267,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSPKIDataType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SPKIData")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKIData")
     public JAXBElement<XmlSPKIDataType> createSPKIData(XmlSPKIDataType value) {
         return new JAXBElement<>(_SPKIData_QNAME, XmlSPKIDataType.class, null, value);
     }
@@ -276,7 +276,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRetrievalMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "RetrievalMethod")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RetrievalMethod")
     public JAXBElement<XmlRetrievalMethodType> createRetrievalMethod(XmlRetrievalMethodType value) {
         return new JAXBElement<>(_RetrievalMethod_QNAME, XmlRetrievalMethodType.class, null, value);
     }
@@ -285,7 +285,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCanonicalizationMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "CanonicalizationMethod")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "CanonicalizationMethod")
     public JAXBElement<XmlCanonicalizationMethodType> createCanonicalizationMethod(XmlCanonicalizationMethodType value) {
         return new JAXBElement<>(_CanonicalizationMethod_QNAME, XmlCanonicalizationMethodType.class, null, value);
     }
@@ -294,7 +294,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignaturePropertyType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureProperty")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperty")
     public JAXBElement<XmlSignaturePropertyType> createSignatureProperty(XmlSignaturePropertyType value) {
         return new JAXBElement<>(_SignatureProperty_QNAME, XmlSignaturePropertyType.class, null, value);
     }
@@ -303,7 +303,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlTransformsType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Transforms")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transforms")
     public JAXBElement<XmlTransformsType> createTransforms(XmlTransformsType value) {
         return new JAXBElement<>(_Transforms_QNAME, XmlTransformsType.class, null, value);
     }
@@ -312,7 +312,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlManifestType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Manifest")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Manifest")
     public JAXBElement<XmlManifestType> createManifest(XmlManifestType value) {
         return new JAXBElement<>(_Manifest_QNAME, XmlManifestType.class, null, value);
     }
@@ -321,7 +321,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureMethod")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureMethod")
     public JAXBElement<XmlSignatureMethodType> createSignatureMethod(XmlSignatureMethodType value) {
         return new JAXBElement<>(_SignatureMethod_QNAME, XmlSignatureMethodType.class, null, value);
     }
@@ -330,7 +330,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlKeyInfoType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "KeyInfo")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyInfo")
     public JAXBElement<XmlKeyInfoType> createKeyInfo(XmlKeyInfoType value) {
         return new JAXBElement<>(_KeyInfo_QNAME, XmlKeyInfoType.class, null, value);
     }
@@ -339,7 +339,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlDigestMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "DigestMethod")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestMethod")
     public JAXBElement<XmlDigestMethodType> createDigestMethod(XmlDigestMethodType value) {
         return new JAXBElement<>(_DigestMethod_QNAME, XmlDigestMethodType.class, null, value);
     }
@@ -348,7 +348,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "MgmtData")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "MgmtData")
     public JAXBElement<String> createMgmtData(String value) {
         return new JAXBElement<>(_MgmtData_QNAME, String.class, null, value);
     }
@@ -357,7 +357,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlReferenceType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Reference")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Reference")
     public JAXBElement<XmlReferenceType> createReference(XmlReferenceType value) {
         return new JAXBElement<>(_Reference_QNAME, XmlReferenceType.class, null, value);
     }
@@ -366,7 +366,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRSAKeyValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "RSAKeyValue")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RSAKeyValue")
     public JAXBElement<XmlRSAKeyValueType> createRSAKeyValue(XmlRSAKeyValueType value) {
         return new JAXBElement<>(_RSAKeyValue_QNAME, XmlRSAKeyValueType.class, null, value);
     }
@@ -375,7 +375,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Signature")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Signature")
     public JAXBElement<XmlSignatureType> createSignature(XmlSignatureType value) {
         return new JAXBElement<>(_Signature_QNAME, XmlSignatureType.class, null, value);
     }
@@ -384,7 +384,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlDSAKeyValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "DSAKeyValue")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DSAKeyValue")
     public JAXBElement<XmlDSAKeyValueType> createDSAKeyValue(XmlDSAKeyValueType value) {
         return new JAXBElement<>(_DSAKeyValue_QNAME, XmlDSAKeyValueType.class, null, value);
     }
@@ -393,7 +393,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedInfoType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignedInfo")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignedInfo")
     public JAXBElement<XmlSignedInfoType> createSignedInfo(XmlSignedInfoType value) {
         return new JAXBElement<>(_SignedInfo_QNAME, XmlSignedInfoType.class, null, value);
     }
@@ -402,7 +402,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlObjectType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Object")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Object")
     public JAXBElement<XmlObjectType> createObject(XmlObjectType value) {
         return new JAXBElement<>(_Object_QNAME, XmlObjectType.class, null, value);
     }
@@ -411,7 +411,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureValue")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureValue")
     public JAXBElement<XmlSignatureValueType> createSignatureValue(XmlSignatureValueType value) {
         return new JAXBElement<>(_SignatureValue_QNAME, XmlSignatureValueType.class, null, value);
     }
@@ -420,7 +420,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlTransformType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Transform")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transform")
     public JAXBElement<XmlTransformType> createTransform(XmlTransformType value) {
         return new JAXBElement<>(_Transform_QNAME, XmlTransformType.class, null, value);
     }
@@ -429,7 +429,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlX509DataType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509Data")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Data")
     public JAXBElement<XmlX509DataType> createX509Data(XmlX509DataType value) {
         return new JAXBElement<>(_X509Data_QNAME, XmlX509DataType.class, null, value);
     }
@@ -438,7 +438,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "DigestValue")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestValue")
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createDigestValue(byte[] value) {
         return new JAXBElement<>(_DigestValue_QNAME, byte[].class, null, value);
@@ -448,7 +448,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignaturePropertiesType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureProperties")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperties")
     public JAXBElement<XmlSignaturePropertiesType> createSignatureProperties(XmlSignaturePropertiesType value) {
         return new JAXBElement<>(_SignatureProperties_QNAME, XmlSignaturePropertiesType.class, null, value);
     }
@@ -457,7 +457,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "KeyName")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyName")
     public JAXBElement<String> createKeyName(String value) {
         return new JAXBElement<>(_KeyName_QNAME, String.class, null, value);
     }
@@ -466,7 +466,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlKeyValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "KeyValue")
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyValue")
     public JAXBElement<XmlKeyValueType> createKeyValue(XmlKeyValueType value) {
         return new JAXBElement<>(_KeyValue_QNAME, XmlKeyValueType.class, null, value);
     }
@@ -475,7 +475,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlX509IssuerSerialType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509IssuerSerial", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509IssuerSerial", scope = XmlX509DataType.class)
     public JAXBElement<XmlX509IssuerSerialType> createXmlX509DataTypeX509IssuerSerial(XmlX509IssuerSerialType value) {
         return new JAXBElement<>(_XmlX509DataTypeX509IssuerSerial_QNAME, XmlX509IssuerSerialType.class, XmlX509DataType.class, value);
     }
@@ -484,7 +484,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509Certificate", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Certificate", scope = XmlX509DataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlX509DataTypeX509Certificate(byte[] value) {
         return new JAXBElement<>(_XmlX509DataTypeX509Certificate_QNAME, byte[].class, XmlX509DataType.class, value);
@@ -494,7 +494,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509SKI", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SKI", scope = XmlX509DataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlX509DataTypeX509SKI(byte[] value) {
         return new JAXBElement<>(_XmlX509DataTypeX509SKI_QNAME, byte[].class, XmlX509DataType.class, value);
@@ -504,7 +504,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509SubjectName", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SubjectName", scope = XmlX509DataType.class)
     public JAXBElement<String> createXmlX509DataTypeX509SubjectName(String value) {
         return new JAXBElement<>(_XmlX509DataTypeX509SubjectName_QNAME, String.class, XmlX509DataType.class, value);
     }
@@ -513,7 +513,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509CRL", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509CRL", scope = XmlX509DataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlX509DataTypeX509CRL(byte[] value) {
         return new JAXBElement<>(_XmlX509DataTypeX509CRL_QNAME, byte[].class, XmlX509DataType.class, value);
@@ -523,7 +523,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link BigInteger }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "HMACOutputLength", scope = XmlSignatureMethodType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "HMACOutputLength", scope = XmlSignatureMethodType.class)
     public JAXBElement<BigInteger> createXmlSignatureMethodTypeHMACOutputLength(BigInteger value) {
         return new JAXBElement<>(_XmlSignatureMethodTypeHMACOutputLength_QNAME, BigInteger.class, XmlSignatureMethodType.class, value);
     }
@@ -532,7 +532,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "PGPKeyID", scope = XmlPGPDataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyID", scope = XmlPGPDataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlPGPDataTypePGPKeyID(byte[] value) {
         return new JAXBElement<>(_XmlPGPDataTypePGPKeyID_QNAME, byte[].class, XmlPGPDataType.class, value);
@@ -542,7 +542,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "PGPKeyPacket", scope = XmlPGPDataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyPacket", scope = XmlPGPDataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlPGPDataTypePGPKeyPacket(byte[] value) {
         return new JAXBElement<>(_XmlPGPDataTypePGPKeyPacket_QNAME, byte[].class, XmlPGPDataType.class, value);
@@ -552,7 +552,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "XPath", scope = XmlTransformType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "XPath", scope = XmlTransformType.class)
     public JAXBElement<String> createXmlTransformTypeXPath(String value) {
         return new JAXBElement<>(_XmlTransformTypeXPath_QNAME, String.class, XmlTransformType.class, value);
     }
@@ -561,7 +561,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SPKISexp", scope = XmlSPKIDataType.class)
+    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKISexp", scope = XmlSPKIDataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlSPKIDataTypeSPKISexp(byte[] value) {
         return new JAXBElement<>(_XmlSPKIDataTypeSPKISexp_QNAME, byte[].class, XmlSPKIDataType.class, value);

--- a/src/main/java/xades4j/xml/bind/xmldsig/ObjectFactory.java
+++ b/src/main/java/xades4j/xml/bind/xmldsig/ObjectFactory.java
@@ -12,10 +12,9 @@ import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlElementDecl;
 import jakarta.xml.bind.annotation.XmlRegistry;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import xades4j.xml.bind.Base64XmlAdapter;
-
-import javax.xml.namespace.QName;
 import java.math.BigInteger;
+import javax.xml.namespace.QName;
+import xades4j.xml.bind.Base64XmlAdapter;
 
 
 /**
@@ -35,40 +34,41 @@ import java.math.BigInteger;
 @XmlRegistry
 public class ObjectFactory {
 
-    private static final QName _PGPData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPData");
-    private static final QName _SPKIData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SPKIData");
-    private static final QName _RetrievalMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "RetrievalMethod");
-    private static final QName _CanonicalizationMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "CanonicalizationMethod");
-    private static final QName _SignatureProperty_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperty");
-    private static final QName _Transforms_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Transforms");
-    private static final QName _Manifest_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Manifest");
-    private static final QName _SignatureMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureMethod");
-    private static final QName _KeyInfo_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyInfo");
-    private static final QName _DigestMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DigestMethod");
-    private static final QName _MgmtData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "MgmtData");
-    private static final QName _Reference_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Reference");
-    private static final QName _RSAKeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "RSAKeyValue");
-    private static final QName _Signature_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Signature");
-    private static final QName _DSAKeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DSAKeyValue");
-    private static final QName _SignedInfo_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignedInfo");
-    private static final QName _Object_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Object");
-    private static final QName _SignatureValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureValue");
-    private static final QName _Transform_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Transform");
-    private static final QName _X509Data_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509Data");
-    private static final QName _DigestValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DigestValue");
-    private static final QName _SignatureProperties_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperties");
-    private static final QName _KeyName_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyName");
-    private static final QName _KeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyValue");
-    private static final QName _XmlX509DataTypeX509IssuerSerial_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509IssuerSerial");
-    private static final QName _XmlX509DataTypeX509Certificate_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509Certificate");
-    private static final QName _XmlX509DataTypeX509SKI_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509SKI");
-    private static final QName _XmlX509DataTypeX509SubjectName_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509SubjectName");
-    private static final QName _XmlX509DataTypeX509CRL_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509CRL");
-    private static final QName _XmlSignatureMethodTypeHMACOutputLength_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "HMACOutputLength");
-    private static final QName _XmlPGPDataTypePGPKeyID_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyID");
-    private static final QName _XmlPGPDataTypePGPKeyPacket_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyPacket");
-    private static final QName _XmlTransformTypeXPath_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "XPath");
-    private static final QName _XmlSPKIDataTypeSPKISexp_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SPKISexp");
+    public static final String ORG_2000_09_XMLDSIG = "http://www.w3.org/2000/09/xmldsig#";
+    private static final QName _PGPData_QNAME = new QName(ORG_2000_09_XMLDSIG, "PGPData");
+    private static final QName _SPKIData_QNAME = new QName(ORG_2000_09_XMLDSIG, "SPKIData");
+    private static final QName _RetrievalMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "RetrievalMethod");
+    private static final QName _CanonicalizationMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "CanonicalizationMethod");
+    private static final QName _SignatureProperty_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureProperty");
+    private static final QName _Transforms_QNAME = new QName(ORG_2000_09_XMLDSIG, "Transforms");
+    private static final QName _Manifest_QNAME = new QName(ORG_2000_09_XMLDSIG, "Manifest");
+    private static final QName _SignatureMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureMethod");
+    private static final QName _KeyInfo_QNAME = new QName(ORG_2000_09_XMLDSIG, "KeyInfo");
+    private static final QName _DigestMethod_QNAME = new QName(ORG_2000_09_XMLDSIG, "DigestMethod");
+    private static final QName _MgmtData_QNAME = new QName(ORG_2000_09_XMLDSIG, "MgmtData");
+    private static final QName _Reference_QNAME = new QName(ORG_2000_09_XMLDSIG, "Reference");
+    private static final QName _RSAKeyValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "RSAKeyValue");
+    private static final QName _Signature_QNAME = new QName(ORG_2000_09_XMLDSIG, "Signature");
+    private static final QName _DSAKeyValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "DSAKeyValue");
+    private static final QName _SignedInfo_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignedInfo");
+    private static final QName _Object_QNAME = new QName(ORG_2000_09_XMLDSIG, "Object");
+    private static final QName _SignatureValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureValue");
+    private static final QName _Transform_QNAME = new QName(ORG_2000_09_XMLDSIG, "Transform");
+    private static final QName _X509Data_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509Data");
+    private static final QName _DigestValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "DigestValue");
+    private static final QName _SignatureProperties_QNAME = new QName(ORG_2000_09_XMLDSIG, "SignatureProperties");
+    private static final QName _KeyName_QNAME = new QName(ORG_2000_09_XMLDSIG, "KeyName");
+    private static final QName _KeyValue_QNAME = new QName(ORG_2000_09_XMLDSIG, "KeyValue");
+    private static final QName _XmlX509DataTypeX509IssuerSerial_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509IssuerSerial");
+    private static final QName _XmlX509DataTypeX509Certificate_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509Certificate");
+    private static final QName _XmlX509DataTypeX509SKI_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509SKI");
+    private static final QName _XmlX509DataTypeX509SubjectName_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509SubjectName");
+    private static final QName _XmlX509DataTypeX509CRL_QNAME = new QName(ORG_2000_09_XMLDSIG, "X509CRL");
+    private static final QName _XmlSignatureMethodTypeHMACOutputLength_QNAME = new QName(ORG_2000_09_XMLDSIG, "HMACOutputLength");
+    private static final QName _XmlPGPDataTypePGPKeyID_QNAME = new QName(ORG_2000_09_XMLDSIG, "PGPKeyID");
+    private static final QName _XmlPGPDataTypePGPKeyPacket_QNAME = new QName(ORG_2000_09_XMLDSIG, "PGPKeyPacket");
+    private static final QName _XmlTransformTypeXPath_QNAME = new QName(ORG_2000_09_XMLDSIG, "XPath");
+    private static final QName _XmlSPKIDataTypeSPKISexp_QNAME = new QName(ORG_2000_09_XMLDSIG, "SPKISexp");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: xades4j.marshalling.xmldsig
@@ -258,7 +258,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlPGPDataType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPData")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "PGPData")
     public JAXBElement<XmlPGPDataType> createPGPData(XmlPGPDataType value) {
         return new JAXBElement<>(_PGPData_QNAME, XmlPGPDataType.class, null, value);
     }
@@ -267,7 +267,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSPKIDataType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKIData")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SPKIData")
     public JAXBElement<XmlSPKIDataType> createSPKIData(XmlSPKIDataType value) {
         return new JAXBElement<>(_SPKIData_QNAME, XmlSPKIDataType.class, null, value);
     }
@@ -276,7 +276,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRetrievalMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RetrievalMethod")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "RetrievalMethod")
     public JAXBElement<XmlRetrievalMethodType> createRetrievalMethod(XmlRetrievalMethodType value) {
         return new JAXBElement<>(_RetrievalMethod_QNAME, XmlRetrievalMethodType.class, null, value);
     }
@@ -285,7 +285,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlCanonicalizationMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "CanonicalizationMethod")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "CanonicalizationMethod")
     public JAXBElement<XmlCanonicalizationMethodType> createCanonicalizationMethod(XmlCanonicalizationMethodType value) {
         return new JAXBElement<>(_CanonicalizationMethod_QNAME, XmlCanonicalizationMethodType.class, null, value);
     }
@@ -294,7 +294,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignaturePropertyType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperty")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureProperty")
     public JAXBElement<XmlSignaturePropertyType> createSignatureProperty(XmlSignaturePropertyType value) {
         return new JAXBElement<>(_SignatureProperty_QNAME, XmlSignaturePropertyType.class, null, value);
     }
@@ -303,7 +303,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlTransformsType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transforms")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Transforms")
     public JAXBElement<XmlTransformsType> createTransforms(XmlTransformsType value) {
         return new JAXBElement<>(_Transforms_QNAME, XmlTransformsType.class, null, value);
     }
@@ -312,7 +312,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlManifestType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Manifest")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Manifest")
     public JAXBElement<XmlManifestType> createManifest(XmlManifestType value) {
         return new JAXBElement<>(_Manifest_QNAME, XmlManifestType.class, null, value);
     }
@@ -321,7 +321,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureMethod")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureMethod")
     public JAXBElement<XmlSignatureMethodType> createSignatureMethod(XmlSignatureMethodType value) {
         return new JAXBElement<>(_SignatureMethod_QNAME, XmlSignatureMethodType.class, null, value);
     }
@@ -330,7 +330,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlKeyInfoType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyInfo")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "KeyInfo")
     public JAXBElement<XmlKeyInfoType> createKeyInfo(XmlKeyInfoType value) {
         return new JAXBElement<>(_KeyInfo_QNAME, XmlKeyInfoType.class, null, value);
     }
@@ -339,7 +339,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlDigestMethodType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestMethod")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "DigestMethod")
     public JAXBElement<XmlDigestMethodType> createDigestMethod(XmlDigestMethodType value) {
         return new JAXBElement<>(_DigestMethod_QNAME, XmlDigestMethodType.class, null, value);
     }
@@ -348,7 +348,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "MgmtData")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "MgmtData")
     public JAXBElement<String> createMgmtData(String value) {
         return new JAXBElement<>(_MgmtData_QNAME, String.class, null, value);
     }
@@ -357,7 +357,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlReferenceType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Reference")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Reference")
     public JAXBElement<XmlReferenceType> createReference(XmlReferenceType value) {
         return new JAXBElement<>(_Reference_QNAME, XmlReferenceType.class, null, value);
     }
@@ -366,7 +366,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlRSAKeyValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RSAKeyValue")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "RSAKeyValue")
     public JAXBElement<XmlRSAKeyValueType> createRSAKeyValue(XmlRSAKeyValueType value) {
         return new JAXBElement<>(_RSAKeyValue_QNAME, XmlRSAKeyValueType.class, null, value);
     }
@@ -375,7 +375,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Signature")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Signature")
     public JAXBElement<XmlSignatureType> createSignature(XmlSignatureType value) {
         return new JAXBElement<>(_Signature_QNAME, XmlSignatureType.class, null, value);
     }
@@ -384,7 +384,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlDSAKeyValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DSAKeyValue")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "DSAKeyValue")
     public JAXBElement<XmlDSAKeyValueType> createDSAKeyValue(XmlDSAKeyValueType value) {
         return new JAXBElement<>(_DSAKeyValue_QNAME, XmlDSAKeyValueType.class, null, value);
     }
@@ -393,7 +393,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignedInfoType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignedInfo")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignedInfo")
     public JAXBElement<XmlSignedInfoType> createSignedInfo(XmlSignedInfoType value) {
         return new JAXBElement<>(_SignedInfo_QNAME, XmlSignedInfoType.class, null, value);
     }
@@ -402,7 +402,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlObjectType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Object")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Object")
     public JAXBElement<XmlObjectType> createObject(XmlObjectType value) {
         return new JAXBElement<>(_Object_QNAME, XmlObjectType.class, null, value);
     }
@@ -411,7 +411,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignatureValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureValue")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureValue")
     public JAXBElement<XmlSignatureValueType> createSignatureValue(XmlSignatureValueType value) {
         return new JAXBElement<>(_SignatureValue_QNAME, XmlSignatureValueType.class, null, value);
     }
@@ -420,7 +420,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlTransformType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transform")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "Transform")
     public JAXBElement<XmlTransformType> createTransform(XmlTransformType value) {
         return new JAXBElement<>(_Transform_QNAME, XmlTransformType.class, null, value);
     }
@@ -429,7 +429,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlX509DataType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Data")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509Data")
     public JAXBElement<XmlX509DataType> createX509Data(XmlX509DataType value) {
         return new JAXBElement<>(_X509Data_QNAME, XmlX509DataType.class, null, value);
     }
@@ -438,7 +438,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestValue")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "DigestValue")
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createDigestValue(byte[] value) {
         return new JAXBElement<>(_DigestValue_QNAME, byte[].class, null, value);
@@ -448,7 +448,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlSignaturePropertiesType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperties")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SignatureProperties")
     public JAXBElement<XmlSignaturePropertiesType> createSignatureProperties(XmlSignaturePropertiesType value) {
         return new JAXBElement<>(_SignatureProperties_QNAME, XmlSignaturePropertiesType.class, null, value);
     }
@@ -457,7 +457,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyName")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "KeyName")
     public JAXBElement<String> createKeyName(String value) {
         return new JAXBElement<>(_KeyName_QNAME, String.class, null, value);
     }
@@ -466,7 +466,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlKeyValueType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyValue")
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "KeyValue")
     public JAXBElement<XmlKeyValueType> createKeyValue(XmlKeyValueType value) {
         return new JAXBElement<>(_KeyValue_QNAME, XmlKeyValueType.class, null, value);
     }
@@ -475,7 +475,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link XmlX509IssuerSerialType }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509IssuerSerial", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509IssuerSerial", scope = XmlX509DataType.class)
     public JAXBElement<XmlX509IssuerSerialType> createXmlX509DataTypeX509IssuerSerial(XmlX509IssuerSerialType value) {
         return new JAXBElement<>(_XmlX509DataTypeX509IssuerSerial_QNAME, XmlX509IssuerSerialType.class, XmlX509DataType.class, value);
     }
@@ -484,7 +484,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Certificate", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509Certificate", scope = XmlX509DataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlX509DataTypeX509Certificate(byte[] value) {
         return new JAXBElement<>(_XmlX509DataTypeX509Certificate_QNAME, byte[].class, XmlX509DataType.class, value);
@@ -494,7 +494,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SKI", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509SKI", scope = XmlX509DataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlX509DataTypeX509SKI(byte[] value) {
         return new JAXBElement<>(_XmlX509DataTypeX509SKI_QNAME, byte[].class, XmlX509DataType.class, value);
@@ -504,7 +504,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SubjectName", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509SubjectName", scope = XmlX509DataType.class)
     public JAXBElement<String> createXmlX509DataTypeX509SubjectName(String value) {
         return new JAXBElement<>(_XmlX509DataTypeX509SubjectName_QNAME, String.class, XmlX509DataType.class, value);
     }
@@ -513,7 +513,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509CRL", scope = XmlX509DataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "X509CRL", scope = XmlX509DataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlX509DataTypeX509CRL(byte[] value) {
         return new JAXBElement<>(_XmlX509DataTypeX509CRL_QNAME, byte[].class, XmlX509DataType.class, value);
@@ -523,7 +523,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link BigInteger }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "HMACOutputLength", scope = XmlSignatureMethodType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "HMACOutputLength", scope = XmlSignatureMethodType.class)
     public JAXBElement<BigInteger> createXmlSignatureMethodTypeHMACOutputLength(BigInteger value) {
         return new JAXBElement<>(_XmlSignatureMethodTypeHMACOutputLength_QNAME, BigInteger.class, XmlSignatureMethodType.class, value);
     }
@@ -532,7 +532,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyID", scope = XmlPGPDataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "PGPKeyID", scope = XmlPGPDataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlPGPDataTypePGPKeyID(byte[] value) {
         return new JAXBElement<>(_XmlPGPDataTypePGPKeyID_QNAME, byte[].class, XmlPGPDataType.class, value);
@@ -542,7 +542,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyPacket", scope = XmlPGPDataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "PGPKeyPacket", scope = XmlPGPDataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlPGPDataTypePGPKeyPacket(byte[] value) {
         return new JAXBElement<>(_XmlPGPDataTypePGPKeyPacket_QNAME, byte[].class, XmlPGPDataType.class, value);
@@ -552,7 +552,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "XPath", scope = XmlTransformType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "XPath", scope = XmlTransformType.class)
     public JAXBElement<String> createXmlTransformTypeXPath(String value) {
         return new JAXBElement<>(_XmlTransformTypeXPath_QNAME, String.class, XmlTransformType.class, value);
     }
@@ -561,7 +561,7 @@ public class ObjectFactory {
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
      * 
      */
-    @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKISexp", scope = XmlSPKIDataType.class)
+    @XmlElementDecl(namespace = ORG_2000_09_XMLDSIG, name = "SPKISexp", scope = XmlSPKIDataType.class)
     @XmlJavaTypeAdapter(Base64XmlAdapter .class)
     public JAXBElement<byte[]> createXmlSPKIDataTypeSPKISexp(byte[] value) {
         return new JAXBElement<>(_XmlSPKIDataTypeSPKISexp_QNAME, byte[].class, XmlSPKIDataType.class, value);

--- a/src/main/java/xades4j/xml/marshalling/BaseJAXBMarshaller.java
+++ b/src/main/java/xades4j/xml/marshalling/BaseJAXBMarshaller.java
@@ -19,6 +19,10 @@ package xades4j.xml.marshalling;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -32,23 +36,18 @@ import xades4j.xml.bind.xades.ObjectFactory;
 import xades4j.xml.bind.xades.XmlSignedPropertiesType;
 import xades4j.xml.bind.xades.XmlUnsignedPropertiesType;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  *
  * @author Luís
  */
 abstract class BaseJAXBMarshaller<TXml>
 {
-    private static final Map<Class, JAXBContext> jaxbContexts;
+    private static final Map<Class<?>, JAXBContext> jaxbContexts;
     static
     {
         try
         {
-            Map<Class, JAXBContext> contexts = new HashMap<>();
+            Map<Class<?>, JAXBContext> contexts = new HashMap<>();
             contexts.put(XmlSignedPropertiesType.class, JAXBContext.newInstance(XmlSignedPropertiesType.class));
             contexts.put(XmlUnsignedPropertiesType.class, JAXBContext.newInstance(XmlUnsignedPropertiesType.class));
             jaxbContexts = Collections.unmodifiableMap(contexts);
@@ -58,7 +57,7 @@ abstract class BaseJAXBMarshaller<TXml>
             throw new UnsupportedOperationException(e);
         }
     }
-    private final Map<Class, QualifyingPropertyDataToXmlConverter<TXml>> converters;
+    private final Map<Class<? extends PropertyDataObject>, QualifyingPropertyDataToXmlConverter<TXml>> converters;
     private final String propsElemName;
 
     protected BaseJAXBMarshaller(int convertersInitialSize, String propsElemName)
@@ -102,7 +101,7 @@ abstract class BaseJAXBMarshaller<TXml>
 
         if (propsNotAlreadyPresent(qualifyingPropsNode))
         // If the QualifyingProperties node doesn't already have an element
-        // for the current type of properties, do a JAXB marshalling into it.
+        // for the current type of properties, do a JAXB marshaling into it.
         {
             doJAXBMarshalling(qualifyingPropsNode, xmlProps);
         } else
@@ -111,8 +110,8 @@ abstract class BaseJAXBMarshaller<TXml>
             // nodes into the appropriate QualifyingProperties children.
             Node tempNode = DOMHelper.createElement(
                     qualifyingPropsNode.getOwnerDocument(), "temp", null, QualifyingProperty.XADES_XMLNS);
-            // - A little work around to inherit the namespace node defined in
-            //   the document. Its just a matter of style.
+            // - A little workaround to inherit the namespace node defined in
+            //   the document. It's just a matter of style.
             qualifyingPropsNode.appendChild(tempNode);
             doJAXBMarshalling(tempNode, xmlProps);
             qualifyingPropsNode.removeChild(tempNode);

--- a/src/main/java/xades4j/xml/marshalling/PropertiesMarshaller.java
+++ b/src/main/java/xades4j/xml/marshalling/PropertiesMarshaller.java
@@ -47,7 +47,7 @@ public interface PropertiesMarshaller
      * @param qualifyingPropsNode the destination node
      * @throws MarshalException if there's an error
      */
-    public void marshal(
+    void marshal(
             SigAndDataObjsPropertiesData props,
             Node qualifyingPropsNode) throws MarshalException;
 }

--- a/src/main/java/xades4j/xml/marshalling/QualifyingPropertyDataToXmlConverter.java
+++ b/src/main/java/xades4j/xml/marshalling/QualifyingPropertyDataToXmlConverter.java
@@ -25,5 +25,5 @@ import xades4j.properties.data.PropertyDataObject;
  */
 interface QualifyingPropertyDataToXmlConverter<TXml>
 {
-    public void convertIntoObjectTree(PropertyDataObject propData, TXml xmlProps, Document doc);
+    void convertIntoObjectTree(PropertyDataObject propData, TXml xmlProps, Document doc);
 }

--- a/src/main/java/xades4j/xml/marshalling/ToXmlCompleteRevocRefsConverter.java
+++ b/src/main/java/xades4j/xml/marshalling/ToXmlCompleteRevocRefsConverter.java
@@ -53,14 +53,14 @@ class ToXmlCompleteRevocRefsConverter implements UnsignedPropertyDataToXmlConver
             for (CRLRef crlRef : complRevocRefsData.getCrlRefs())
             {
                 XmlCRLIdentifierType xmlCrlId = new XmlCRLIdentifierType();
-                xmlCrlId.setIssueTime(DatatypeFactory.newInstance().newXMLGregorianCalendar(crlRef.issueTime));
-                xmlCrlId.setIssuer(crlRef.issuerDN);
-                xmlCrlId.setNumber(crlRef.serialNumber); // May be null.
+                xmlCrlId.setIssueTime(DatatypeFactory.newInstance().newXMLGregorianCalendar(crlRef.getIssueTime()));
+                xmlCrlId.setIssuer(crlRef.getIssuerDN());
+                xmlCrlId.setNumber(crlRef.getSerialNumber()); // May be null.
 
                 XmlDigestAlgAndValueType xmlDigest = new XmlDigestAlgAndValueType();
                 XmlDigestMethodType xmlDigestMethod = new XmlDigestMethodType();
-                xmlDigestMethod.setAlgorithm(crlRef.digestAlgUri);
-                xmlDigest.setDigestValue(crlRef.digestValue);
+                xmlDigestMethod.setAlgorithm(crlRef.getDigestAlgUri());
+                xmlDigest.setDigestValue(crlRef.getDigestValue());
                 xmlDigest.setDigestMethod(xmlDigestMethod);
 
                 XmlCRLRefType xmlCrlRef = new XmlCRLRefType();

--- a/src/main/java/xades4j/xml/marshalling/ToXmlUtils.java
+++ b/src/main/java/xades4j/xml/marshalling/ToXmlUtils.java
@@ -16,6 +16,8 @@
  */
 package xades4j.xml.marshalling;
 
+import java.util.EnumMap;
+import java.util.List;
 import xades4j.properties.IdentifierType;
 import xades4j.properties.ObjectIdentifier;
 import xades4j.properties.data.BaseCertRefsData;
@@ -28,9 +30,6 @@ import xades4j.xml.bind.xades.XmlObjectIdentifierType;
 import xades4j.xml.bind.xades.XmlQualifierType;
 import xades4j.xml.bind.xmldsig.XmlDigestMethodType;
 import xades4j.xml.bind.xmldsig.XmlX509IssuerSerialType;
-
-import java.util.EnumMap;
-import java.util.List;
 
 /**
  * @author Luís
@@ -45,8 +44,8 @@ class ToXmlUtils
     static
     {
         identifierTypeConv = new EnumMap<>(IdentifierType.class);
-        identifierTypeConv.put(IdentifierType.OIDAsURI, XmlQualifierType.OID_AS_URI);
-        identifierTypeConv.put(IdentifierType.OIDAsURN, XmlQualifierType.OID_AS_URN);
+        identifierTypeConv.put(IdentifierType.OID_AS_URI, XmlQualifierType.OID_AS_URI);
+        identifierTypeConv.put(IdentifierType.OID_AS_URN, XmlQualifierType.OID_AS_URN);
     }
 
     static XmlObjectIdentifierType getXmlObjectId(ObjectIdentifier objId)
@@ -81,14 +80,14 @@ class ToXmlUtils
         for (CertRef certRef : certRefsData.getCertRefs())
         {
             certDigestMethod = new XmlDigestMethodType();
-            certDigestMethod.setAlgorithm(certRef.digestAlgUri);
+            certDigestMethod.setAlgorithm(certRef.getDigestAlgUri());
             certDigest = new XmlDigestAlgAndValueType();
             certDigest.setDigestMethod(certDigestMethod);
-            certDigest.setDigestValue(certRef.digestValue);
+            certDigest.setDigestValue(certRef.getDigestValue());
 
             issuerSerial = new XmlX509IssuerSerialType();
-            issuerSerial.setX509IssuerName(certRef.issuerDN);
-            issuerSerial.setX509SerialNumber(certRef.serialNumber);
+            issuerSerial.setX509IssuerName(certRef.getIssuerDN());
+            issuerSerial.setX509SerialNumber(certRef.getSerialNumber());
 
             certID = new XmlCertIDType();
             certID.setCertDigest(certDigest);

--- a/src/main/java/xades4j/xml/marshalling/ToXmlUtils.java
+++ b/src/main/java/xades4j/xml/marshalling/ToXmlUtils.java
@@ -46,6 +46,8 @@ class ToXmlUtils
         identifierTypeConv = new EnumMap<>(IdentifierType.class);
         identifierTypeConv.put(IdentifierType.OID_AS_URI, XmlQualifierType.OID_AS_URI);
         identifierTypeConv.put(IdentifierType.OID_AS_URN, XmlQualifierType.OID_AS_URN);
+        identifierTypeConv.put(IdentifierType.OIDAsURI, XmlQualifierType.OIDAsURI);
+        identifierTypeConv.put(IdentifierType.OIDAsURN, XmlQualifierType.OIDAsURN);
     }
 
     static XmlObjectIdentifierType getXmlObjectId(ObjectIdentifier objId)

--- a/src/main/java/xades4j/xml/marshalling/UnsupportedDataObjectException.java
+++ b/src/main/java/xades4j/xml/marshalling/UnsupportedDataObjectException.java
@@ -25,7 +25,7 @@ import xades4j.properties.data.PropertyDataObject;
  */
 public class UnsupportedDataObjectException extends MarshalException
 {
-    private final PropertyDataObject dataObject;
+    private final transient PropertyDataObject dataObject;
 
     public UnsupportedDataObjectException(PropertyDataObject dataObject)
     {

--- a/src/main/java/xades4j/xml/marshalling/algorithms/AlgorithmsParametersMarshallingProviderImpl.java
+++ b/src/main/java/xades4j/xml/marshalling/algorithms/AlgorithmsParametersMarshallingProviderImpl.java
@@ -40,7 +40,7 @@ final class AlgorithmsParametersMarshallingProviderImpl implements AlgorithmsPar
     @Override
     public List<Node> marshalParameters(Algorithm alg, Document doc) throws UnsupportedAlgorithmException
     {
-        AlgorithmParametersMarshaller marshaller = this.marshallers.get(alg.getClass());
+        AlgorithmParametersMarshaller<Algorithm> marshaller = (AlgorithmParametersMarshaller<Algorithm>) this.marshallers.get(alg.getClass());
         if (marshaller == null)
         {
             throw new UnsupportedAlgorithmException("AlgorithmParametersMarshaller not available", alg.getUri());

--- a/src/main/java/xades4j/xml/marshalling/algorithms/AlgorithmsParametersMarshallingProviderImpl.java
+++ b/src/main/java/xades4j/xml/marshalling/algorithms/AlgorithmsParametersMarshallingProviderImpl.java
@@ -17,13 +17,12 @@
 package xades4j.xml.marshalling.algorithms;
 
 import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import xades4j.UnsupportedAlgorithmException;
 import xades4j.algorithms.Algorithm;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Luís

--- a/src/main/java/xades4j/xml/marshalling/algorithms/ExclusiveCanonicalXMLParamsMarshaller.java
+++ b/src/main/java/xades4j/xml/marshalling/algorithms/ExclusiveCanonicalXMLParamsMarshaller.java
@@ -35,7 +35,7 @@ class ExclusiveCanonicalXMLParamsMarshaller
         }else
         {
             InclusiveNamespaces inclusive = new InclusiveNamespaces(doc, alg.getInclusiveNamespacePrefixes());
-            return Collections.singletonList((Node) inclusive.getElement());
+            return Collections.singletonList(inclusive.getElement());
         }
     }
 }

--- a/src/main/java/xades4j/xml/marshalling/algorithms/XPath2FilterTransformParamsMarshaller.java
+++ b/src/main/java/xades4j/xml/marshalling/algorithms/XPath2FilterTransformParamsMarshaller.java
@@ -43,7 +43,7 @@ final class XPath2FilterTransformParamsMarshaller implements AlgorithmParameters
         
         for (XPath2Filter filter : filters)
         {
-            XPath2FilterContainer c = null;
+            XPath2FilterContainer c;
             String filterType = filter.getFilterType();
             if (XPath2FilterContainer.INTERSECT.equals(filterType))
             {

--- a/src/main/java/xades4j/xml/unmarshalling/DefaultQualifyingPropertiesUnmarshaller.java
+++ b/src/main/java/xades4j/xml/unmarshalling/DefaultQualifyingPropertiesUnmarshaller.java
@@ -46,7 +46,7 @@ final class DefaultQualifyingPropertiesUnmarshaller
         }
     }
 
-    private final UnmarshallerModule[] modules;
+    private final UnmarshallerModule<?>[] modules;
 
     public DefaultQualifyingPropertiesUnmarshaller()
     {
@@ -78,7 +78,7 @@ final class DefaultQualifyingPropertiesUnmarshaller
         }
 
         // Iterate the modules to convert the different types of properties.
-        for (UnmarshallerModule module : modules)
+        for (UnmarshallerModule<?> module : modules)
         {
             module.convertProperties(xmlQualifyingProps, qualifyingProps, propertyDataCollector);
         }
@@ -87,7 +87,7 @@ final class DefaultQualifyingPropertiesUnmarshaller
     @Override
     public void setAcceptUnknownProperties(boolean accept)
     {
-        for (UnmarshallerModule module : modules)
+        for (UnmarshallerModule<?> module : modules)
         {
             module.setAcceptUnknownProperties(accept);
         }

--- a/src/main/java/xades4j/xml/unmarshalling/DefaultQualifyingPropertiesUnmarshaller.java
+++ b/src/main/java/xades4j/xml/unmarshalling/DefaultQualifyingPropertiesUnmarshaller.java
@@ -62,7 +62,7 @@ final class DefaultQualifyingPropertiesUnmarshaller
             Element qualifyingProps,
             QualifyingPropertiesDataCollector propertyDataCollector) throws UnmarshalException
     {
-        XmlQualifyingPropertiesType xmlQualifyingProps = null;
+        XmlQualifyingPropertiesType xmlQualifyingProps;
         try
         {
             // Create the JAXB unmarshaller and unmarshalProperties the root JAXB element

--- a/src/main/java/xades4j/xml/unmarshalling/FromXmlCommitmentTypeConverter.java
+++ b/src/main/java/xades4j/xml/unmarshalling/FromXmlCommitmentTypeConverter.java
@@ -45,21 +45,7 @@ class FromXmlCommitmentTypeConverter implements SignedDataObjPropFromXmlConv
 
         for (XmlCommitmentTypeIndicationType xmlCommitment : xmlCommitments)
         {
-            List<String> objsRefs = xmlCommitment.getObjectReference();
-            Object allDataObjs = xmlCommitment.getAllSignedDataObjects();
-
-            if (objsRefs.isEmpty())
-            {
-                // Should be AllSignedDataObjects.
-                objsRefs = null;
-                if (null == allDataObjs)
-                {
-                    throw new PropertyUnmarshalException("ObjectReference or AllSignedDataObjects have to be present", CommitmentTypePropertyBase.PROP_NAME);
-                }
-            } else if (allDataObjs != null)
-            {
-                throw new PropertyUnmarshalException("Both ObjectReference and AllSignedDataObjects are present", CommitmentTypePropertyBase.PROP_NAME);
-            }
+            List<String> objsRefs = getObjsRefs(xmlCommitment);
 
             CommitmentTypeData commTypeData = new CommitmentTypeData(
                     xmlCommitment.getCommitmentTypeId().getIdentifier().getValue(),
@@ -79,7 +65,7 @@ class FromXmlCommitmentTypeConverter implements SignedDataObjPropFromXmlConv
                             throw new PropertyUnmarshalException("Qualifiers with multiple children are not support", CommitmentTypePropertyBase.PROP_NAME);
                         }
 
-                        qualifiers.add((String) xmlQualifier.getContent().get(0));
+                        qualifiers.add(xmlQualifier.getContent().get(0));
                     }
                 }
                 
@@ -88,5 +74,24 @@ class FromXmlCommitmentTypeConverter implements SignedDataObjPropFromXmlConv
 
             propertyDataCollector.addCommitmentType(commTypeData);
         }
+    }
+
+    private static List<String> getObjsRefs(XmlCommitmentTypeIndicationType xmlCommitment) throws PropertyUnmarshalException {
+        List<String> objsRefs = xmlCommitment.getObjectReference();
+        Object allDataObjs = xmlCommitment.getAllSignedDataObjects();
+
+        if (objsRefs.isEmpty())
+        {
+            // Should be AllSignedDataObjects.
+            objsRefs = null;
+            if (null == allDataObjs)
+            {
+                throw new PropertyUnmarshalException("ObjectReference or AllSignedDataObjects have to be present", CommitmentTypePropertyBase.PROP_NAME);
+            }
+        } else if (allDataObjs != null)
+        {
+            throw new PropertyUnmarshalException("Both ObjectReference and AllSignedDataObjects are present", CommitmentTypePropertyBase.PROP_NAME);
+        }
+        return objsRefs;
     }
 }

--- a/src/main/java/xades4j/xml/unmarshalling/FromXmlSignaturePolicyConverter.java
+++ b/src/main/java/xades4j/xml/unmarshalling/FromXmlSignaturePolicyConverter.java
@@ -17,6 +17,7 @@
 package xades4j.xml.unmarshalling;
 
 import jakarta.xml.bind.JAXBElement;
+import java.util.List;
 import xades4j.properties.QualifyingProperty;
 import xades4j.properties.SignaturePolicyBase;
 import xades4j.properties.data.SignaturePolicyData;
@@ -25,8 +26,6 @@ import xades4j.xml.bind.xades.XmlSigPolicyQualifiersListType;
 import xades4j.xml.bind.xades.XmlSignaturePolicyIdType;
 import xades4j.xml.bind.xades.XmlSignaturePolicyIdentifierType;
 import xades4j.xml.bind.xades.XmlSignedSignaturePropertiesType;
-
-import java.util.List;
 
 /**
  *
@@ -75,10 +74,10 @@ class FromXmlSignaturePolicyConverter implements SignedSigPropFromXmlConv
             List<Object> content = xmlQualifier.getContent();
             if (content.size() == 1 && content.get(0) instanceof JAXBElement)
             {
-                JAXBElement xmlSPURI = (JAXBElement)content.get(0);
+                JAXBElement<String> xmlSPURI = (JAXBElement<String>)content.get(0);
                 if (xmlSPURI.getName().getLocalPart().equals("SPURI") && xmlSPURI.getName().getNamespaceURI().equals(QualifyingProperty.XADES_XMLNS))
                 {
-                    return (String) xmlSPURI.getValue();
+                    return xmlSPURI.getValue();
                 }
             }
         }

--- a/src/main/java/xades4j/xml/unmarshalling/FromXmlUtils.java
+++ b/src/main/java/xades4j/xml/unmarshalling/FromXmlUtils.java
@@ -69,6 +69,8 @@ class FromXmlUtils
         identifierTypeConv.put(null, IdentifierType.URI);
         identifierTypeConv.put(XmlQualifierType.OID_AS_URI, IdentifierType.OID_AS_URI);
         identifierTypeConv.put(XmlQualifierType.OID_AS_URN, IdentifierType.OID_AS_URN);
+        identifierTypeConv.put(XmlQualifierType.OIDAsURI, IdentifierType.OIDAsURI);
+        identifierTypeConv.put(XmlQualifierType.OIDAsURN, IdentifierType.OIDAsURN);
     }
 
     static ObjectIdentifier getObjectIdentifier(XmlObjectIdentifierType xmlObjId)

--- a/src/main/java/xades4j/xml/unmarshalling/FromXmlUtils.java
+++ b/src/main/java/xades4j/xml/unmarshalling/FromXmlUtils.java
@@ -67,8 +67,8 @@ class FromXmlUtils
     {
         identifierTypeConv = new HashMap<>(3);
         identifierTypeConv.put(null, IdentifierType.URI);
-        identifierTypeConv.put(XmlQualifierType.OID_AS_URI, IdentifierType.OIDAsURI);
-        identifierTypeConv.put(XmlQualifierType.OID_AS_URN, IdentifierType.OIDAsURN);
+        identifierTypeConv.put(XmlQualifierType.OID_AS_URI, IdentifierType.OID_AS_URI);
+        identifierTypeConv.put(XmlQualifierType.OID_AS_URN, IdentifierType.OID_AS_URN);
     }
 
     static ObjectIdentifier getObjectIdentifier(XmlObjectIdentifierType xmlObjId)

--- a/src/main/java/xades4j/xml/unmarshalling/QualifyingPropertiesDataCollector.java
+++ b/src/main/java/xades4j/xml/unmarshalling/QualifyingPropertiesDataCollector.java
@@ -17,19 +17,19 @@
 package xades4j.xml.unmarshalling;
 
 import xades4j.properties.data.AllDataObjsTimeStampData;
-import xades4j.properties.data.SigningTimeData;
-import xades4j.properties.data.SigningCertificateData;
-import xades4j.properties.data.SignatureProdPlaceData;
-import xades4j.properties.data.DataObjectFormatData;
 import xades4j.properties.data.CommitmentTypeData;
 import xades4j.properties.data.CompleteCertificateRefsData;
 import xades4j.properties.data.CompleteRevocationRefsData;
+import xades4j.properties.data.DataObjectFormatData;
 import xades4j.properties.data.GenericDOMData;
 import xades4j.properties.data.IndividualDataObjsTimeStampData;
 import xades4j.properties.data.OtherPropertyData;
 import xades4j.properties.data.SignaturePolicyData;
+import xades4j.properties.data.SignatureProdPlaceData;
 import xades4j.properties.data.SignatureTimeStampData;
 import xades4j.properties.data.SignerRoleData;
+import xades4j.properties.data.SigningCertificateData;
+import xades4j.properties.data.SigningTimeData;
 
 /**
  * Passed to a {@link QualifyingPropertiesUnmarshaller} to collect the property
@@ -44,34 +44,34 @@ import xades4j.properties.data.SignerRoleData;
  */
 public interface QualifyingPropertiesDataCollector
 {
-    public void setSigningTime(SigningTimeData sigTimeData);
+    void setSigningTime(SigningTimeData sigTimeData);
 
-    public void setSignatureProdPlace(SignatureProdPlaceData sigProdPlaceData);
+    void setSignatureProdPlace(SignatureProdPlaceData sigProdPlaceData);
 
-    public void setSignerRole(SignerRoleData signerRoleData);
+    void setSignerRole(SignerRoleData signerRoleData);
 
-    public void setSigningCertificate(SigningCertificateData signingCertData);
+    void setSigningCertificate(SigningCertificateData signingCertData);
 
-    public void setSignaturePolicy(SignaturePolicyData sigPolicyData);
+    void setSignaturePolicy(SignaturePolicyData sigPolicyData);
 
-    public void setCompleteCertificateRefs(
+    void setCompleteCertificateRefs(
             CompleteCertificateRefsData completeCertRefsData);
 
-    public void setCompleteRevocRefs(
+    void setCompleteRevocRefs(
             CompleteRevocationRefsData completeRecovRefsData);
 
-    public void addSignatureTimeStamp(SignatureTimeStampData sigTSData);
+    void addSignatureTimeStamp(SignatureTimeStampData sigTSData);
 
-    public void addCommitmentType(CommitmentTypeData commitmentData);
+    void addCommitmentType(CommitmentTypeData commitmentData);
 
-    public void addDataObjectFormat(DataObjectFormatData formatData);
+    void addDataObjectFormat(DataObjectFormatData formatData);
 
-    public void addAllDataObjsTimeStamp(AllDataObjsTimeStampData objsTSData);
+    void addAllDataObjsTimeStamp(AllDataObjsTimeStampData objsTSData);
 
-    public void addIndividualDataObjsTimeStamp(
+    void addIndividualDataObjsTimeStamp(
             IndividualDataObjsTimeStampData objsTSData);
 
-    public void addGenericDOMData(GenericDOMData domData);
+    void addGenericDOMData(GenericDOMData domData);
 
-    public void addOther(OtherPropertyData otherData);
+    void addOther(OtherPropertyData otherData);
 }

--- a/src/main/java/xades4j/xml/unmarshalling/QualifyingPropertiesUnmarshaller.java
+++ b/src/main/java/xades4j/xml/unmarshalling/QualifyingPropertiesUnmarshaller.java
@@ -33,7 +33,7 @@ public interface QualifyingPropertiesUnmarshaller
      * should be returned with instances of {@code GenericDOMData}.
      * @param accept {@code true} if unknown properties should be accepted
      */
-    public void setAcceptUnknownProperties(boolean accept);
+    void setAcceptUnknownProperties(boolean accept);
 
     /**
      * Unmarshal the properties in the given {@code QualifyingProperties} node.
@@ -42,7 +42,7 @@ public interface QualifyingPropertiesUnmarshaller
      * @param propertyDataCollector the collector of property data objects
      * @throws UnmarshalException if there's an error (may be {@link PropertyUnmarshalException})
      */
-    public void unmarshalProperties(
+    void unmarshalProperties(
             Element qualifyingProps,
             QualifyingPropertiesDataCollector propertyDataCollector) throws UnmarshalException;
 }

--- a/src/main/java/xades4j/xml/unmarshalling/QualifyingPropertyFromXmlConverter.java
+++ b/src/main/java/xades4j/xml/unmarshalling/QualifyingPropertyFromXmlConverter.java
@@ -22,7 +22,7 @@ package xades4j.xml.unmarshalling;
  */
 interface QualifyingPropertyFromXmlConverter<TXml>
 {
-    public void convertFromObjectTree(
+    void convertFromObjectTree(
             TXml xmlProps,
             QualifyingPropertiesDataCollector propertyDataCollector) throws PropertyUnmarshalException;
 }

--- a/src/test/java/xades4j/production/SignerEPESTest.java
+++ b/src/test/java/xades4j/production/SignerEPESTest.java
@@ -16,6 +16,7 @@
  */
 package xades4j.production;
 
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.w3c.dom.Document;
@@ -24,8 +25,6 @@ import xades4j.properties.IdentifierType;
 import xades4j.properties.ObjectIdentifier;
 import xades4j.properties.SignaturePolicyIdentifierProperty;
 import xades4j.providers.SignaturePolicyInfoProvider;
-
-import java.io.ByteArrayInputStream;
 
 /**
  * @author Luís
@@ -43,7 +42,7 @@ class SignerEPESTest extends SignerTestBase
         Element elemToSign = doc.getDocumentElement();
 
         SignaturePolicyInfoProvider policyInfoProvider = () -> new SignaturePolicyIdentifierProperty(
-                new ObjectIdentifier("oid:/1.2.4.0.9.4.5", IdentifierType.OIDAsURI, "Policy description"),
+                new ObjectIdentifier("oid:/1.2.4.0.9.4.5", IdentifierType.OID_AS_URI, "Policy description"),
                 new ByteArrayInputStream("Test policy input stream".getBytes()))
                 .withLocationUrl(locationUrl);
 

--- a/src/test/java/xades4j/properties/DataObjectDescTest.java
+++ b/src/test/java/xades4j/properties/DataObjectDescTest.java
@@ -16,6 +16,11 @@
  */
 package xades4j.properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -25,9 +30,6 @@ import xades4j.algorithms.XPath2FilterTransform;
 import xades4j.algorithms.XPath2FilterTransform.XPath2Filter;
 import xades4j.algorithms.XPathTransform;
 import xades4j.utils.SignatureServicesTestBase;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Luís
@@ -98,10 +100,10 @@ class DataObjectDescTest
     void testHasProperties()
     {
         DataObjectDesc instance = new DataObjectDescTestImpl();
-        assertEquals(false, instance.hasProperties());
+        assertFalse(instance.hasProperties());
 
         instance.withDataObjectFormat(new DataObjectFormatProperty());
-        assertEquals(true, instance.hasProperties());
+        assertTrue(instance.hasProperties());
     }
 
     /**
@@ -111,13 +113,13 @@ class DataObjectDescTest
     void testGetSignedDataObjProps()
     {
         DataObjectDesc instance = new DataObjectDescTestImpl();
-        assertEquals(instance.getSignedDataObjProps().size(), 0);
+        assertEquals(0, instance.getSignedDataObjProps().size());
 
         instance.withDataObjectFormat(new DataObjectFormatProperty());
-        assertEquals(instance.getSignedDataObjProps().size(), 1);
+        assertEquals(1, instance.getSignedDataObjProps().size());
     }
 
-    public class DataObjectDescTestImpl extends DataObjectDesc
+    public static class DataObjectDescTestImpl extends DataObjectDesc
     {
     }
 }

--- a/src/test/java/xades4j/properties/DataObjectFormatPropertyTest.java
+++ b/src/test/java/xades4j/properties/DataObjectFormatPropertyTest.java
@@ -16,15 +16,14 @@
  */
 package xades4j.properties;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Collection;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Luís
@@ -94,7 +93,7 @@ class DataObjectFormatPropertyTest
         documentationUris.add("doc");
 
         instance.withDocumentationUris(documentationUris);
-        assertEquals(instance.getDocumentationUris().size(), 1);
+        assertEquals(1, instance.getDocumentationUris().size());
     }
 
     /**

--- a/src/test/java/xades4j/providers/impl/FileSystemKeyStoreKeyingDataProviderTest.java
+++ b/src/test/java/xades4j/providers/impl/FileSystemKeyStoreKeyingDataProviderTest.java
@@ -16,13 +16,8 @@
  */
 package xades4j.providers.impl;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import xades4j.utils.SignatureServicesTestBase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.FileInputStream;
 import java.security.Security;
@@ -30,9 +25,13 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import xades4j.utils.SignatureServicesTestBase;
 
 /**
  * @author Luís
@@ -103,7 +102,7 @@ public class FileSystemKeyStoreKeyingDataProviderTest
     void testGetSigningCertificateChain(FileSystemKeyStoreKeyingDataProvider keyingProvider, X509Certificate signCert) throws Exception
     {
         List<X509Certificate> certChain = keyingProvider.getSigningCertificateChain();
-        assertEquals(certChain.size(), 3);
+        assertEquals(3, certChain.size());
         assertEquals(certChain.get(0), signCert);
     }
 }


### PR DESCRIPTION
I made some changes again. I think I finished this work now. 

What one could do further:

* There are some tests missing asserts. We could add AssertJ and use `AssertDoesNotThrow(()->) `in this cases. But I don't think that's worth it. 
* Sonar doesn't like it, when there are more than 5 parents. There are 6 or 7 from some classes.
* Some method are quite big and complex. Sonar suggests to simplify them.
* * public QualifyingProperty verify(
* * public void convertFromObjectTree(
* * void buildKeyInfo(
* * static KeyInfoRes process(
* * static ReferencesRes processReferences(
* the two ObjectFactory classes are really big, they should be split and 
* the constructors of SignerXXX have more than 10 parameter, we could introduce a builder pattern for them
* sonar suggests in `private static class AllCertificatesSelector implements Selector<X509CertificateHolder>`: A copy constructor, copy factory or a custom copy function are suitable alternatives to the Object.clone
* Optional should not be used in parameters